### PR TITLE
basicSA : add quantization

### DIFF
--- a/BasicSA.py
+++ b/BasicSA.py
@@ -82,5 +82,100 @@ def generatingOutput(yu_list, pu_list, puv_list):
     sum_xu = sum(yu_list) - sum(pu_list) + sum(puv_list)
     return sum_xu
 
+def stochasticQuantization(x, q, p):
+    # x = local model of user i
+    # q = quantization level
+    # p = modulo p
+
+    # var_x = quantized x
+    var_x = representNegativeInt(q * stochasticRounding(x, q), p)
+    return var_x
+
+def stochasticRounding(x, q):
+    # x = local model of user i
+    # q = quantization level
+
+    # ret_list = return value list after rounding x
+    # prob_list = probability list (weight for random.choices)
+    # ret_x = rounded x
+
+    ret_list = [math.floor(q * x) / q, (math.floor(q * x) + 1) / q]
+    prob_list = [1 - (q * x - math.floor(q * x)), q * x - math.floor(q * x)]
+    ret_x = random.choices(ret_list, prob_list)
+    return ret_x
+
+def mapping(x, p):
+    """mapping(x, p) is to represent a negative integer in the finite field
+    by using two’s complement representation"""
+    # % mod 연산으로 대체가 가능한 부분인가...?
+    if x < 0:
+        return p + x
+    else:
+        return x
+
+def SS_Matrix(G):
+    # G = the number of groups
+    B = [['*' for x in range(G)] for y in range(G)]
+    for g in range(G - 1):
+        for r in range(G - g - 1):
+            l = 2 * g + r
+            B[l % G][g] = g
+            B[l % G][g + r + 1] = g
+    for i in range(G):
+        for j in range(G):
+            if B[i][j] == '*':
+                B[i][j] = j
+    return B
+
+# generate G quantizers randomly
+def generateQuantizers_heteroQ(G):
+    Q = []
+    for i in range(G):
+        Q.append(random.randint(1, 100))
+    return Q
+
+# return quantization level q
+def returnQuantizer(mode, l, g, B, Q):
+    # mode = homo quantization(0) or hetero quantization(1)
+    # l = segment index
+    # g = group index
+    # B = SS_Matrix
+    # Q = a set of quantization level
+
+    # q = quantization level
+    if mode == 0:  # homo quantization
+        q = Q[0]
+        return q
+    elif mode == 1:  # hetero quantization
+        q = Q[B[l][g]]
+        return q
+    else:
+        print("wrong input")
+        return 0
+
+def Quantization(x, G, q, r1, r2):
+    # x = local model value of user i
+    # G = the number of groups
+    # q = quantization level
+    # [r1, r2] = quantization range
+    """ q = returnQuantizer(mode, l, g, B, Q)
+    => Quantization(x, G, q) can do both homo quantization and hetero quantization. """
+
+    # delK = quantization interval
+    # T = discrete value from quantization range
+    delK = (r2 - r1) / (q - 1)
+    T = []
+    for l in range(0, G):
+        T.append(r1 + l * delK)
+
+    for l in range(0, G - 1):
+        if T[l] <= x < T[l + 1]:
+            ret_list = [T[l], T[l+1]]
+            prob_list = [(x - T[l]) / (T[l + 1] - T[l]), 1-((x - T[l]) / (T[l + 1] - T[l]))]
+            ret_x = random.choices(ret_list, prob_list)
+            break
+    return ret_x
+
+
 # just for testing
 # if __name__ == "__main__":

--- a/BasicSA.py
+++ b/BasicSA.py
@@ -88,7 +88,7 @@ def stochasticQuantization(x, q, p):
     # p = modulo p
 
     # var_x = quantized x
-    var_x = representNegativeInt(q * stochasticRounding(x, q), p)
+    var_x = mappingX(q * stochasticRounding(x, q), p)
     return var_x
 
 def stochasticRounding(x, q):
@@ -104,8 +104,8 @@ def stochasticRounding(x, q):
     ret_x = random.choices(ret_list, prob_list)
     return ret_x
 
-def mapping(x, p):
-    """mapping(x, p) is to represent a negative integer in the finite field
+def mappingX(x, p):
+    """mappingX(x, p) is to represent a negative integer in the finite field
     by using two’s complement representation"""
     # % mod 연산으로 대체가 가능한 부분인가...?
     if x < 0:
@@ -162,7 +162,7 @@ def Quantization(x, G, q, r1, r2):
     => Quantization(x, G, q) can do both homo quantization and hetero quantization. """
 
     # delK = quantization interval
-    # T = discrete value from quantization range
+    # T = discrete value from quantization range point list
     delK = (r2 - r1) / (q - 1)
     T = []
     for l in range(0, G):


### PR DESCRIPTION
quantization 모든 과정에서 quantizer는 함수 parameter로 받아오도록 하였습니다.

**Stochastic Quantization**

- stochasticRounding 함수 - local model x를 확률에 따라 반올림한 후 return합니다.
- mappingX 함수 - 양수는 그대로, 음수를 양의 정수로 변환시켜 mapping한 후 return합니다.

**Quantization(homo, hetero)**

- SS_Matrix 함수 - group과 segment 별로 달라지는 quantizer 지정을 위한 SS_Matrix를 생성해 return합니다. 
- returnQuantizer 함수 - 각 user의 quantizer q를 지정하여 return합니다. homo인 경우 모두 동일한 q를, hetero인 경우 SS_Matrix에 따라 q를 지정합니다.

- Quantization 함수 - returnQuantizer 함수를 통해 지정된 q를 parameter로 받아 local model x를 양자화하여 반환합니다. quantization interval에 따라 나뉘는 구간을 리스트 T로 선언하고, 속하는 구간 중 확률에 따라 mapping 하여 return합니다.
- generateQuantizers_heteroQ 함수 - hetero quantization을 위해 quantizer를 G개 만큼 랜덤 생성하고 이를 list Q로 반환하는 함수입니다. (현재는 임시로 생성해놓았으며 후에 quantizer 지정 방식 결정 후 사용여부를 정하고, 구체화하려 합니다)