### PR TITLE
Server: Add support for setup round and server-gui

### DIFF
--- a/server/BasicSAServer.py
+++ b/server/BasicSAServer.py
@@ -1,7 +1,18 @@
-import json
+import os, sys
+sys.path.append(os.path.dirname(os.path.abspath(os.path.dirname(__file__))))
+
 from MainServer import MainServer
+from BasicSA import getCommonValues
 
 users = {}
+
+# broadcast common value
+def setUp():
+    server = MainServer('ServerSetUp')
+    server.start()
+
+    commonValues = getCommonValues()
+    server.broadcast(commonValues)
 
 def advertiseKeys():
     server = MainServer('AdvertiseKeys')
@@ -50,5 +61,6 @@ def shareKeys():
     server.foreach(response)
 
 if __name__ == "__main__":
+    setUp()
     advertiseKeys() # Round 0
     shareKeys() # Round 1

--- a/server/BasicSAServer.py
+++ b/server/BasicSAServer.py
@@ -7,15 +7,15 @@ from BasicSA import getCommonValues
 users = {}
 
 # broadcast common value
-def setUp(port):
-    server = MainServer('ServerSetUp', port)
+def setUp():
+    server = MainServer('ServerSetUp', 7000)
     server.start()
 
     commonValues = getCommonValues()
     server.broadcast(commonValues)
 
-def advertiseKeys(port):
-    server = MainServer('AdvertiseKeys', port)
+def advertiseKeys():
+    server = MainServer('AdvertiseKeys', 7010)
     server.start()
 
     # requests example: {"c_pk":"VALUE", "s_pk": "VALUE"}
@@ -33,8 +33,8 @@ def advertiseKeys(port):
     
     server.broadcast(response)
 
-def shareKeys(port):
-    server = MainServer('ShareKeys', port)
+def shareKeys():
+    server = MainServer('ShareKeys', 7020)
     server.start()
 
     # (one) request example: [ 0, (0, 0, e00), (0, 1, e01) ... ]
@@ -59,8 +59,3 @@ def shareKeys(port):
                 pass
     
     server.foreach(response)
-
-if __name__ == "__main__":
-    setUp()
-    advertiseKeys() # Round 0
-    shareKeys() # Round 1

--- a/server/BasicSAServer.py
+++ b/server/BasicSAServer.py
@@ -7,15 +7,15 @@ from BasicSA import getCommonValues
 users = {}
 
 # broadcast common value
-def setUp():
-    server = MainServer('ServerSetUp')
+def setUp(port):
+    server = MainServer('ServerSetUp', port)
     server.start()
 
     commonValues = getCommonValues()
     server.broadcast(commonValues)
 
-def advertiseKeys():
-    server = MainServer('AdvertiseKeys')
+def advertiseKeys(port):
+    server = MainServer('AdvertiseKeys', port)
     server.start()
 
     # requests example: {"c_pk":"VALUE", "s_pk": "VALUE"}
@@ -33,8 +33,8 @@ def advertiseKeys():
     
     server.broadcast(response)
 
-def shareKeys():
-    server = MainServer('ShareKeys')
+def shareKeys(port):
+    server = MainServer('ShareKeys', port)
     server.start()
 
     # (one) request example: [ 0, (0, 0, e00), (0, 1, e01) ... ]

--- a/server/MainServer.py
+++ b/server/MainServer.py
@@ -3,7 +3,8 @@ import json
 import time
 
 class MainServer:
-    host, port = 'localhost', 20
+    host = 'localhost'
+    port = 20
     SIZE = 1024
     ENCODING = 'ascii'
     t = 0 # threshold #temp
@@ -13,9 +14,9 @@ class MainServer:
     userNum = 0
     requests = []
 
-    def __init__(self, tag) -> None:
+    def __init__(self, tag, port):
         self.tag = tag
-        pass
+        self.port = port
 
     def start(self):
         self.startTime = self.endTime = time.time()

--- a/server/gui.py
+++ b/server/gui.py
@@ -1,10 +1,16 @@
 from tkinter import *
+import BasicSAServer
 
 root = Tk()
 root.title("Server")
 root.geometry("640x400+100+100")
 
-setupBtn = Button(root, text = "SetUp")
-setupBtn.pack()
+SARound = ["SetUp", "AdvertiseKeys", "ShareKeys"]
+func = [BasicSAServer.setUp, BasicSAServer.advertiseKeys, BasicSAServer.shareKeys]
+btn = []
+
+for i, round in enumerate(SARound):
+    btn.append(Button(root, text=round, command=func[i]))
+    btn[i].pack()
 
 root.mainloop()


### PR DESCRIPTION
## 개요
Server 에 set-up 하는 단계 추가 및 MainServer 수정, gui 에 연결

## 상세 내용
- Server 에 set-up 하는 단계를 추가했습니다. : n, t, g, p, R 을 넘겨줍니다. (각각 number of users, threshold, generator, prime, domain)
- `MainServer` 를 생성할 때 `port` 를 넘겨주도록 변경하였습니다. 기존의 형태는 여러 round 에서 같은 port 를 사용해서 문제가 발생할 수 있기 때문입니다.
- gui 에 버튼을 3개 만들어서 setUp, advertiseKeys, shareKeys 에 대한 서버를 실행하는 함수를 연결했습니다.
