### PR TITLE
Refactor: server-client, secure protocol

### DIFF
--- a/BasicSA.py
+++ b/BasicSA.py
@@ -9,8 +9,8 @@ def getCommonValues():
     n = 4 #temp
     t = 3 #temp
     R = 100 #temp
-    (g, p) = sp.generator() #temp
-    commonValues = {"n": n, "t": t, "g": g, "p": p, "R": R}
+    #(g, p) = sp.generator()
+    commonValues = {"n": n, "t": t, "g": 10, "p": 10, "R": R}
     return commonValues
 
 # Generate two key pairs

--- a/CommonValue.py
+++ b/CommonValue.py
@@ -1,0 +1,8 @@
+from enum import Enum
+
+class BasicSARound(Enum):
+    SetUp = 7000
+    AdvertiseKeys = 7010
+    ShareKeys = 7020
+    MaskedInputCollection = 7030
+    Unmasking = 7040

--- a/SecureProtocol.py
+++ b/SecureProtocol.py
@@ -16,17 +16,13 @@ def primesInRange(x, y):
             prime_list.append(n)
     return prime_list
 
-prime_list = primesInRange(100, 200) #temp
-g = random.choice(prime_list)
-p = random.choice(prime_list)
-
 # key generate
-def generate():
+def generate(g, p):
     pri_key = random.randrange(50000, 90000) #temp
     pub_key = g ** pri_key % p
     return (pub_key, pri_key)
 
-def agree(sk, pk):
+def agree(sk, pk, p):
     key = pk ** sk % p
     return key
 
@@ -59,7 +55,7 @@ def get_c_pk(tot):
         e += 1
     return e
 
-def generate_c():
+def generate_c(g, p):
     totient = (p - 1) * (g - 1)
     c_pk = get_c_pk(totient)
     c_sk = get_c_sk(c_pk, totient)

--- a/SecureProtocol.py
+++ b/SecureProtocol.py
@@ -35,13 +35,13 @@ def gcd(a, b):
         a, b = b, a % b
     return a
 
-def encrypt(s_uv, plaintext):
-    key, n = s_uv
+def encrypt(s_uv, plaintext, n):
+    key = s_uv
     cipher = [(ord(char) ** key) % n for char in plaintext]
     return cipher
 
-def decrypt(s_uv, ciphertext):
-    key, n = s_uv
+def decrypt(s_uv, ciphertext, n):
+    key = s_uv
     plain = [chr((char ** key) % n) for char in ciphertext]
     return ''.join(plain)
 

--- a/SecureProtocol.py
+++ b/SecureProtocol.py
@@ -40,9 +40,9 @@ def encrypt(s_uv, plaintext):
     cipher = [(ord(char) ** key) % n for char in plaintext]
     return cipher
 
-def decrypt(s_uv, evu):
+def decrypt(s_uv, ciphertext):
     key, n = s_uv
-    plain = [chr((char ** key) % n) for char in evu]
+    plain = [chr((char ** key) % n) for char in ciphertext]
     return ''.join(plain)
 
 def get_c_sk(e, tot):

--- a/client/BasicSAClient.py
+++ b/client/BasicSAClient.py
@@ -133,7 +133,7 @@ class BasicSAClient:
         response = sendRequestAndReceive(self.HOST, PORT, tag, request)
 
         # U3 = survived users in round2(MaskedInputCollection) = users_last used in round4(unmasking)
-        self.U3 = response['yu_list']
+        self.U3 = response['users']
 
 
     def unmasking(self):
@@ -149,7 +149,6 @@ class BasicSAClient:
 
         # U2 = survived users in round1(shareKeys) = users_previous
         U2 = list(self.others_euv.keys())
-        U3 = list(map(int, self.U3.keys())) # make str key to int
 
         s_sk_shares_dic, bu_shares_dic = sa.unmasking(
             self.u, 
@@ -157,7 +156,7 @@ class BasicSAClient:
             self.others_euv, 
             c_pk_dic, 
             U2, 
-            U3,
+            self.U3,
             self.commonValues["R"])
         # requests example: {"idx": 0, "ssk_shares": {2: s20_sk, 3: s30_sk, ...}, "bu_shares": {1: b10, 4: b40, ...}]}
         request = {"idx": self.u, "ssk_shares": str(s_sk_shares_dic), "bu_shares": str(bu_shares_dic)}

--- a/client/BasicSAClient.py
+++ b/client/BasicSAClient.py
@@ -3,19 +3,8 @@ sys.path.append(os.path.dirname(os.path.abspath(os.path.dirname(__file__))))
 import BasicSA as sa
 from CommonValue import BasicSARound
 
-HOST = 'localhost'
 SIZE = 2048
 ENCODING = 'ascii'
-xu = 0  # temp. local model of this client
-
-commonValues = {}  # {"n": n, "t": t, "g": g, "p": p, "R": R} from server in setup stage
-u = 0  # u = user index
-my_keys = {}  # c_pk, c_sk, s_pk, s_sk of this client
-others_keys = {}  # other users' public key dic
-euv_list = []  # euv of this client
-others_euv = {}
-bu = 0  # random element to be used as a seed for PRG
-U3 = []  # survived users in round2(MaskedInputCollection)
 
 def sendRequestAndReceive(host, port, tag, request):
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -34,7 +23,7 @@ def sendRequestAndReceive(host, port, tag, request):
     response = ''
     try:
         response = json.loads(receivedStr)
-        print(f"[Client] receive response {response}")
+        print(f"[{tag}] receive response {response}")
         return response
     except json.decoder.JSONDecodeError:
         #raise Exception(f"[{tag}] Server response with: {response}")
@@ -43,103 +32,138 @@ def sendRequestAndReceive(host, port, tag, request):
     finally:
         s.close()
 
-def setUp():
-    tag = BasicSARound.SetUp.name
-    PORT = BasicSARound.SetUp.value
+class BasicSAClient:
+    HOST = 'localhost'
+    xu = 0  # temp. local model of this client
 
-    # response: {"n": n, "t": t, "g": g, "p": p, "R": R}
-    response = sendRequestAndReceive(HOST, PORT, tag, {})
-    commonValues = response
+    commonValues = {}  # {"n": n, "t": t, "g": g, "p": p, "R": R} from server in setup stage
+    u = 0  # u = user index
+    my_keys = {}  # c_pk, c_sk, s_pk, s_sk of this client
+    others_keys = {}  # other users' public key dic
+    euv_list = []  # euv of this client
+    others_euv = {}
+    bu = 0  # random element to be used as a seed for PRG
+    U3 = []  # survived users in round2(MaskedInputCollection)
 
+    def setUp(self):
+        tag = BasicSARound.SetUp.name
+        PORT = BasicSARound.SetUp.value
 
-def advertiseKeys():
-    tag = BasicSARound.AdvertiseKeys.name
-    PORT = BasicSARound.AdvertiseKeys.value
+        # response: {"n": n, "t": t, "g": g, "p": p, "R": R}
+        response = sendRequestAndReceive(self.HOST, PORT, tag, {})
+        self.commonValues = response
 
-    ((c_pk, c_sk), (s_pk, s_sk)) = sa.generateKeyPairs()
-    my_keys["c_pk"] = c_pk
-    my_keys["c_sk"] = c_sk
-    my_keys["s_pk"] = s_pk
-    my_keys["s_sk"] = s_sk
-    request = {"c_pk": c_pk, "s_pk": s_pk}
+    def advertiseKeys(self):
+        tag = BasicSARound.AdvertiseKeys.name
+        PORT = BasicSARound.AdvertiseKeys.value
 
-    # send {"c_pk": c_pk, "s_pk": s_pk} to server in json format
-    # receive other users' public keys from server in json format
-    response = sendRequestAndReceive(HOST, PORT, tag, request)
+        ((c_pk, c_sk), (s_pk, s_sk)) = sa.generateKeyPairs()
+        self.my_keys["c_pk"] = c_pk
+        self.my_keys["c_sk"] = c_sk 
+        self.my_keys["s_pk"] = s_pk
+        self.my_keys["s_sk"] = s_sk
+        request = {"c_pk": c_pk, "s_pk": s_pk}
 
-    # store response on client
-    # example: {"0": {"c_pk": "2123", "s_pk": "3333", "index": 0}, "1": {"c_pk": "1111", "s_pk": "2222", "index": 1}}
-    others_keys = response
+        # send {"c_pk": c_pk, "s_pk": s_pk} to server in json format
+        # receive other users' public keys from server in json format
+        response = sendRequestAndReceive(self.HOST, PORT, tag, request)
 
-
-def shareKeys():
-    tag = BasicSARound.ShareKeys.name
-    PORT = BasicSARound.ShareKeys.value
-
-    for i, user_dic in others_keys.items():
-        if my_keys["c_pk"] == user_dic["c_pk"] and my_keys["s_pk"] == user_dic["s_pk"]:
-            u = user_dic["index"]  # u = user index
-            break
-        else:
-            continue
-
-    # t = threshold, u = user index
-    # request = [[u, v1, euv], [u, v2, euv], ...]
-    euv_list, bu = sa.generateSharesOfMask(commonValues["t"], u, my_keys["s_sk"], my_keys["c_sk"], others_keys, commonValues["R"])
-    request = euv_list
-
-    # receive euv_list from server in json format
-    # change euv_list format from json to list and store
-    response = sendRequestAndReceive(HOST, PORT, tag, request)
-
-    # store euv from server to client in dic
-    """for v, euv in enumerate(response):  # example response = ["e01", "e11"]
-        others_euv[v] = euv
-    """
-    # if response format {v: euv}. example = {0: "e00", 1: "e10"}
-    for v, euv in response.items():
-        others_euv[v] = euv
+        # store response on client
+        # example: {"0": {"c_pk": "2123", "s_pk": "3333", "index": 0}, "1": {"c_pk": "1111", "s_pk": "2222", "index": 1}}
+        self.others_keys = response
 
 
-def MaskedInputCollection():
-    tag = BasicSARound.MaskedInputCollection.name
-    PORT = BasicSARound.MaskedInputCollection.value
-    request = {}
-    response = {}
+    def shareKeys(self):
+        tag = BasicSARound.ShareKeys.name
+        PORT = BasicSARound.ShareKeys.value
 
-    s_pk_dic = {}
-    for i, user_dic in others_keys.items():
-        v = i
-        s_pk_dic[i] = user_dic.get("s_pk")
-    yu = sa.generateMaskedInput(u, bu, xu, my_keys["s_sk"], euv_list, s_pk_dic, commonValues["R"])
-    request = {u: yu}  # request example: {0: y0}
+        for i, user_dic in self.others_keys.items():
+            print(user_dic)
+            if self.my_keys["c_pk"] == user_dic["c_pk"] and self.my_keys["s_pk"] == user_dic["s_pk"]:
+                u = user_dic["index"]  # u = user index
+                break
+            else:
+                continue
 
-    # receive sending_yu_list from server
-    response = sendRequestAndReceive(HOST, PORT, tag, request)
+        # t = threshold, u = user index
+        # request = [[u, v1, euv], [u, v2, euv], ...]
+        euv_list, bu = sa.generateSharesOfMask(
+            self.commonValues["t"], 
+            u, 
+            self.my_keys["s_sk"], 
+            self.my_keys["c_sk"], 
+            self.others_keys, 
+            self.commonValues["R"])
+        self.bu = bu
+        request = euv_list
 
-    # U3 = survived users in round2(MaskedInputCollection) = users_last used in round4(unmasking)
-    U3 = response
+        # receive euv_list from server in json format
+        response = sendRequestAndReceive(self.HOST, PORT, tag, request)
+
+        # store euv from server to client in dic
+        """for v, euv in enumerate(response):  # example response = ["e01", "e11"]
+            others_euv[v] = euv
+        """
+        # if response format {v: euv}. example = {0: "e00", 1: "e10"}
+        for v, euv in response.items():
+            self.others_euv[v] = euv
 
 
-def Unmasking():
-    tag = BasicSARound.Unmasking.name
-    PORT = BasicSARound.Unmasking.value
-    request = {}
-    s_sk_shares_dic = {}
-    bu_shares_dic = {}
-    temp_request = (s_sk_shares_dic, bu_shares_dic)
+    def MaskedInputCollection(self):
+        tag = BasicSARound.MaskedInputCollection.name
+        PORT = BasicSARound.MaskedInputCollection.value
+        request = {}
+        response = {}
 
-    c_pk_dic = {}
-    for i, user_dic in others_keys.items():
-        v = i
-        c_pk_dic[i] = user_dic.get("c_pk")
+        s_pk_dic = {}
+        for i, user_dic in self.others_keys.items():
+            v = i
+            s_pk_dic[i] = user_dic.get("s_pk")
+        yu = sa.generateMaskedInput(
+            self.u, 
+            self.bu, 
+            self.xu, 
+            self.my_keys["s_sk"], 
+            self.euv_list, 
+            s_pk_dic, 
+            self.commonValues["R"])
+        request = {self.u: yu}  # request example: {0: y0}
 
-    # U2 = survived users in round1(shareKeys) = users_previous
-    U2 = list(others_euv.keys())
+        # receive sending_yu_list from server
+        response = sendRequestAndReceive(self.HOST, PORT, tag, request)
 
-    # requests example: {u: [{0: s02_sk, 1: s03_sk, ...}, {1: b01, 4: b04, ...}]}
-    temp_request = sa.unmasking(u, my_keys["c_sk"], euv_list, c_pk_dic, U2, U3)
-    request = {u: list(temp_request)}
+        # U3 = survived users in round2(MaskedInputCollection) = users_last used in round4(unmasking)
+        self.U3 = response
 
-    # send u and dropped users' s_sk, survived users' bu in json format
-    sendRequestAndReceive(HOST, PORT, tag, request)
+
+    def Unmasking(self):
+        tag = BasicSARound.Unmasking.name
+        PORT = BasicSARound.Unmasking.value
+        request = {}
+        s_sk_shares_dic = {}
+        bu_shares_dic = {}
+        temp_request = (s_sk_shares_dic, bu_shares_dic)
+
+        c_pk_dic = {}
+        for i, user_dic in self.others_keys.items():
+            v = i
+            c_pk_dic[i] = user_dic.get("c_pk")
+
+        # U2 = survived users in round1(shareKeys) = users_previous
+        U2 = list(self.others_euv.keys())
+
+        # requests example: {u: [{0: s02_sk, 1: s03_sk, ...}, {1: b01, 4: b04, ...}]}
+        temp_request = sa.unmasking(
+            self.u, 
+            self.my_keys["c_sk"], 
+            self.euv_list, 
+            c_pk_dic, 
+            U2, 
+            self.U3)
+        request = {self.u: list(temp_request)}
+
+        # send u and dropped users' s_sk, survived users' bu in json format
+        sendRequestAndReceive(self.HOST, PORT, tag, request)
+
+if __name__ == "__main__":
+    client = BasicSAClient() # test

--- a/client/BasicSAClient.py
+++ b/client/BasicSAClient.py
@@ -106,10 +106,10 @@ class BasicSAClient:
         """
         # if response format {v: euv}. example = {0: "e00", 1: "e10"}
         for v, euv in response.items():
-            self.others_euv[v] = euv
+            self.others_euv[int(v)] = euv
 
 
-    def MaskedInputCollection(self):
+    def maskedInputCollection(self):
         tag = BasicSARound.MaskedInputCollection.name
         PORT = BasicSARound.MaskedInputCollection.value
         request = {}
@@ -117,8 +117,8 @@ class BasicSAClient:
 
         s_pk_dic = {}
         for i, user_dic in self.others_keys.items():
-            v = i
-            s_pk_dic[i] = user_dic.get("s_pk")
+            v = int(i)
+            s_pk_dic[v] = user_dic.get("s_pk")
         yu = sa.generateMaskedInput(
             self.u, 
             self.bu, 
@@ -127,16 +127,16 @@ class BasicSAClient:
             self.euv_list, 
             s_pk_dic, 
             self.commonValues["R"])
-        request = {self.u: yu}  # request example: {0: y0}
+        request = {"idx": self.u, "yu": yu}  # request example: {"idx":0, "yu":y0}
 
         # receive sending_yu_list from server
         response = sendRequestAndReceive(self.HOST, PORT, tag, request)
 
         # U3 = survived users in round2(MaskedInputCollection) = users_last used in round4(unmasking)
-        self.U3 = response
+        self.U3 = response['yu_list']
 
 
-    def Unmasking(self):
+    def unmasking(self):
         tag = BasicSARound.Unmasking.name
         PORT = BasicSARound.Unmasking.value
         request = {}
@@ -168,3 +168,4 @@ class BasicSAClient:
 
 if __name__ == "__main__":
     client = BasicSAClient() # test
+    client.maskedInputCollection()

--- a/client/BasicSAClient.py
+++ b/client/BasicSAClient.py
@@ -80,7 +80,7 @@ class BasicSAClient:
         for i, user_dic in self.others_keys.items():
             print(user_dic)
             if self.my_keys["c_pk"] == user_dic["c_pk"] and self.my_keys["s_pk"] == user_dic["s_pk"]:
-                u = user_dic["index"]  # u = user index
+                self.u = user_dic["index"]  # u = user index
                 break
             else:
                 continue
@@ -89,13 +89,13 @@ class BasicSAClient:
         # request = [[u, v1, euv], [u, v2, euv], ...]
         euv_list, bu = sa.generateSharesOfMask(
             self.commonValues["t"], 
-            u, 
+            self.u, 
             self.my_keys["s_sk"], 
             self.my_keys["c_sk"], 
             self.others_keys, 
             self.commonValues["R"])
         self.bu = bu
-        request = euv_list
+        request = {self.u: euv_list}
 
         # receive euv_list from server in json format
         response = sendRequestAndReceive(self.HOST, PORT, tag, request)
@@ -159,7 +159,8 @@ class BasicSAClient:
             self.euv_list, 
             c_pk_dic, 
             U2, 
-            self.U3)
+            self.U3,
+            self.commonValues["R"])
         request = {self.u: list(temp_request)}
 
         # send u and dropped users' s_sk, survived users' bu in json format

--- a/client/BasicSAClient.py
+++ b/client/BasicSAClient.py
@@ -139,29 +139,28 @@ class BasicSAClient:
     def unmasking(self):
         tag = BasicSARound.Unmasking.name
         PORT = BasicSARound.Unmasking.value
-        request = {}
         s_sk_shares_dic = {}
         bu_shares_dic = {}
-        temp_request = (s_sk_shares_dic, bu_shares_dic)
 
         c_pk_dic = {}
         for i, user_dic in self.others_keys.items():
-            v = i
-            c_pk_dic[i] = user_dic.get("c_pk")
+            v = int(i)
+            c_pk_dic[v] = user_dic.get("c_pk")
 
         # U2 = survived users in round1(shareKeys) = users_previous
         U2 = list(self.others_euv.keys())
+        U3 = list(self.U3.keys())
 
-        # requests example: {u: [{0: s02_sk, 1: s03_sk, ...}, {1: b01, 4: b04, ...}]}
-        temp_request = sa.unmasking(
+        s_sk_shares_dic, bu_shares_dic = sa.unmasking(
             self.u, 
             self.my_keys["c_sk"], 
-            self.euv_list, 
+            self.others_euv, 
             c_pk_dic, 
             U2, 
-            self.U3,
+            U3,
             self.commonValues["R"])
-        request = {self.u: list(temp_request)}
+        # requests example: {"idx": 0, "ssk_shares": {2: s20_sk, 3: s30_sk, ...}, "bu_shares": {1: b10, 4: b40, ...}]}
+        request = {"idx": self.u, "ssk_shares": s_sk_shares_dic, "bu_shares": bu_shares_dic}
 
         # send u and dropped users' s_sk, survived users' bu in json format
         sendRequestAndReceive(self.HOST, PORT, tag, request)

--- a/client/clientgui.py
+++ b/client/clientgui.py
@@ -7,7 +7,7 @@ root.geometry("640x400+100+100")
 
 client = BasicSAClient()
 SARound = ["SetUp", "AdvertiseKeys", "ShareKeys", "MaskedInputCollection", "Unmasking"]
-func = [client.setUp, client.advertiseKeys, client.shareKeys, client.MaskedInputCollection, client.Unmasking]
+func = [client.setUp, client.advertiseKeys, client.shareKeys, client.maskedInputCollection, client.unmasking]
 btn = []
 for i, round in enumerate(SARound):
     btn.append(Button(root, text = round, command = func[i]))

--- a/client/clientgui.py
+++ b/client/clientgui.py
@@ -1,12 +1,13 @@
 from tkinter import *
-import BasicSAClient as sac
+from BasicSAClient import BasicSAClient
 
 root = Tk()
 root.title("Client")
 root.geometry("640x400+100+100")
 
+client = BasicSAClient()
 SARound = ["SetUp", "AdvertiseKeys", "ShareKeys", "MaskedInputCollection", "Unmasking"]
-func = [sac.setUp, sac.advertiseKeys, sac.shareKeys, sac.MaskedInputCollection, sac.Unmasking]
+func = [client.setUp, client.advertiseKeys, client.shareKeys, client.MaskedInputCollection, client.Unmasking]
 btn = []
 for i, round in enumerate(SARound):
     btn.append(Button(root, text = round, command = func[i]))

--- a/server/BasicSAServer.py
+++ b/server/BasicSAServer.py
@@ -34,14 +34,8 @@ def advertiseKeys():
     for v, request in enumerate(requests):
         requestData = request[1]  # (socket, data)
         users[v] = requestData  # store on server
-
-        requestData['index'] = v  # add index
-        requestData = request[1] # (socket, data)
-        users[v] = requestData # store on server
-
         requestData['index'] = v # add index
         response[v] = requestData
-
     server.broadcast(response)
 
 
@@ -143,7 +137,4 @@ def Unmasking():
     
     
 if __name__ == "__main__":
-    advertiseKeys() # Round 0
-    shareKeys() # Round 1
-    MaskedInputCollection() # Round 2
-    Unmasking() # Round 4
+    advertiseKeys()

--- a/server/BasicSAServer.py
+++ b/server/BasicSAServer.py
@@ -2,17 +2,18 @@ import os, sys
 sys.path.append(os.path.dirname(os.path.abspath(os.path.dirname(__file__))))
 
 from MainServer import MainServer
-from BasicSA import getCommonValues, reconstructPuv, reconstructPu
+from BasicSA import getCommonValues, reconstructPvu, reconstructPu, reconstruct
 from CommonValue import BasicSARound
 
-users = {}
-yu = 0
+users_keys = {}
+sum_yu = 0
 usersNum = 0
 threshold = 0
+R = 0
 
 # broadcast common value
 def setUp():
-    global usersNum, threshold
+    global usersNum, threshold, R
 
     tag = BasicSARound.SetUp.name
     port = BasicSARound.SetUp.value
@@ -22,10 +23,11 @@ def setUp():
     commonValues = getCommonValues()
     usersNum = commonValues["n"]
     threshold = commonValues["t"]
+    R = commonValues["R"]
     server.broadcast(commonValues)
 
 def advertiseKeys():
-    global users
+    global users_keys
 
     tag = BasicSARound.AdvertiseKeys.name
     port = BasicSARound.AdvertiseKeys.value
@@ -40,7 +42,7 @@ def advertiseKeys():
     response = {}
     for v, request in enumerate(requests):
         requestData = request[1]  # (socket, data)
-        users[v] = requestData  # store on server
+        users_keys[v] = requestData  # store on server
         requestData['index'] = v # add index
         response[v] = requestData
     server.broadcast(response)
@@ -75,7 +77,7 @@ def shareKeys():
     server.foreach(response)
     
 def maskedInputCollection():
-    global yu
+    global sum_yu
 
     tag = BasicSARound.MaskedInputCollection.name
     port = BasicSARound.MaskedInputCollection.value
@@ -91,60 +93,62 @@ def maskedInputCollection():
     for request in requests:
         requestData = request[1]  # (socket, data)
         response[requestData["idx"]] = requestData["yu"]
-        yu = yu + int(requestData["yu"])
+        sum_yu = sum_yu + int(requestData["yu"])
 
     server.broadcast({"yu_list": response})
 
 def unmasking():
-    global usersNum
+    global usersNum, sum_yu, R, users_keys
+    sum_xu = sum_yu # sum(xu) is sum of user3's xu
 
     tag = BasicSARound.Unmasking.name
     port = BasicSARound.Unmasking.value
     server = MainServer(tag, port)
     server.start()
 
-    # if u2, u3 dropped
-    # requests example: { [{0: s02_sk, 1: s03_sk, ...}, {1: b01, 4: b04, ...}], ... }
+    # (one) request: {"idx": u, "ssk_shares": s_sk_shares_dic, "bu_shares": bu_shares_dic}
+    # if u2, u3 dropped, requests: [{"idx": 0, "ssk_shares": {2: s20_sk, 3: s30_sk}, "bu_shares": {1: b10, 4: b40}}, ...]
     requests = server.requests
 
-    drop_usr = {}       # {0: {0: s02_sk, 1: s03_sk, ...}, 1: {0: s12_sk, 1: s13_sk, ...}, ... }
-    survive_usr = {}    # {0: {1: b01, 4: b04, ...}, 1: {0: b10, 4: b14, ...}, ... }
-    share_list = {}     # {0: [s02_sk, s12_sk, ... ], 1: [s03_sk, s13_sk, ... ], ... }
-    bu_list = {}        # {0: [b10, b40, ... ], 1: [b01, b41, ... ], 2: [], ... }
-    requestData = []
+    s_sk_shares_dic = {}     # {2: [s20_sk, s21_sk, ... ], 3: [s30_sk, s31_sk, ... ], ... }
+    bu_shares_dic = {}       # {0: [b10, b04, ... ], 1: [b10, b14, ... ], ... }
 
+    # get s_sk_shares_dic, bu_shares_dic of user2\3, user3
     for request in requests:
-        requestData.append(requests[request])
-        for i, data in enumerate(requestData):
-            drop_usr[i] = data[0]
-            survive_usr[i] = data[1]
-
-    drop_num = usersNum - server.userNum
-    for n in range(drop_num):
-        share_list[n] = []
-    for n in range(usersNum):
-        bu_list[n] = []
-    for n in range(drop_num):
-        for i in range(server.userNum):
-            share_list[n].append(drop_usr[i][n])
-    for n in range(usersNum):
-        for i in range(server.userNum):
-            if n in survive_usr[i]:
-                bu_list[n].append(survive_usr[i][n])
+        requestData = request[1]  # (socket, data)
+        ssk_shares = requestData["ssk_shares"]
+        for i, share in ssk_shares.items():
+            try: 
+                s_sk_shares_dic[i].append(share)
+            except KeyError:
+                s_sk_shares_dic[i] = [share]
+                pass
+        bu_shares = requestData["bu_shares"]
+        for i, share in bu_shares.items():
+            try: 
+                bu_shares_dic[i].append(share)
+            except KeyError:
+                bu_shares_dic[i] = [share]
+                pass
     
+    # reconstruct s_sk of users2\3
+    s_sk_dic = {}
+    for i, ssk_shares in s_sk_shares_dic.items(): # first, reconstruct ssk_u <- ssk_u,v
+        s_sk_dic[i] = reconstruct(ssk_shares)
     # recompute p_vu
-    for d_usr in range(drop_num):
-        for usr in range(server.userNum):
-            p_uv = reconstructPuv(d_usr, usr, share_list[d_usr])
-            yu = yu + p_uv
+    user3list = list(bu_shares_dic.keys())
+    for u in user3list:
+        for v, s_sk in s_sk_dic.items():
+            pvu = reconstructPvu(v, u, s_sk, users_keys[u]["s_pk"], R)
+            sum_xu = sum_xu + pvu
     
-    # recompute p_u
-    for i in range(usersNum):
-        p_u = reconstructPu(bu_list[i])
-        yu = yu - p_u
+    # recompute p_u of users3
+    for i, bu_shares in bu_shares_dic.items(): # first, reconstruct ssk_u <- ssk_u,v
+        pu = reconstructPu(bu_shares, R)
+        sum_xu = sum_xu - pu
+    
+    return sum_xu
 
-    # z = sum(yu) - sum(p_u) + sum(p_vu)
-    
-    
+
 if __name__ == "__main__":
     maskedInputCollection()

--- a/server/BasicSAServer.py
+++ b/server/BasicSAServer.py
@@ -4,6 +4,7 @@ sys.path.append(os.path.dirname(os.path.abspath(os.path.dirname(__file__))))
 from MainServer import MainServer
 from BasicSA import getCommonValues, reconstructPvu, reconstructPu, reconstruct
 from CommonValue import BasicSARound
+from ast import literal_eval
 
 users_keys = {}
 sum_yu = 0
@@ -116,14 +117,14 @@ def unmasking():
     # get s_sk_shares_dic, bu_shares_dic of user2\3, user3
     for request in requests:
         requestData = request[1]  # (socket, data)
-        ssk_shares = requestData["ssk_shares"]
+        ssk_shares = literal_eval(requestData["ssk_shares"])
         for i, share in ssk_shares.items():
             try: 
                 s_sk_shares_dic[i].append(share)
             except KeyError:
                 s_sk_shares_dic[i] = [share]
                 pass
-        bu_shares = requestData["bu_shares"]
+        bu_shares = literal_eval(requestData["bu_shares"])
         for i, share in bu_shares.items():
             try: 
                 bu_shares_dic[i].append(share)
@@ -151,4 +152,9 @@ def unmasking():
 
 
 if __name__ == "__main__":
+    setUp()
+    advertiseKeys()
+    shareKeys()    
     maskedInputCollection()
+    final = unmasking()
+    print("[Server] sum_xu: ", final)

--- a/server/BasicSAServer.py
+++ b/server/BasicSAServer.py
@@ -7,7 +7,7 @@ from CommonValue import BasicSARound
 from ast import literal_eval
 
 users_keys = {}
-sum_yu = 0
+yu_list = []
 usersNum = 0
 threshold = 0
 R = 0
@@ -78,7 +78,7 @@ def shareKeys():
     server.foreach(response)
     
 def maskedInputCollection():
-    global sum_yu
+    global yu_list
 
     tag = BasicSARound.MaskedInputCollection.name
     port = BasicSARound.MaskedInputCollection.value
@@ -89,18 +89,18 @@ def maskedInputCollection():
     # (one) request example: {"idx":0, "yu":y0}
     requests = server.requests
 
-    # response example: { "yu_list": [{0: y0}, {1: y1}, {2: y2}, ... ] }
-    response = {}
+    # response example: { "users": [0, 1, 2 ... ] }
+    response = []
     for request in requests:
         requestData = request[1]  # (socket, data)
-        response[requestData["idx"]] = requestData["yu"]
-        sum_yu = sum_yu + int(requestData["yu"])
+        response.append(int(requestData["idx"]))
+        yu_list.append(int(requestData["yu"]))
 
-    server.broadcast({"yu_list": response})
+    server.broadcast({"users": response})
 
 def unmasking():
-    global usersNum, sum_yu, R, users_keys
-    sum_xu = sum_yu # sum(xu) is sum of user3's xu
+    global usersNum, yu_list, R, users_keys
+    sum_xu = sum(yu_list) # sum(xu) is sum of user3's xu
 
     tag = BasicSARound.Unmasking.name
     port = BasicSARound.Unmasking.value
@@ -148,7 +148,8 @@ def unmasking():
         pu = reconstructPu(bu_shares, R)
         sum_xu = sum_xu - pu
     
-    return sum_xu
+    avg = sum_xu / len(yu_list)
+    return avg
 
 
 if __name__ == "__main__":
@@ -157,4 +158,4 @@ if __name__ == "__main__":
     shareKeys()    
     maskedInputCollection()
     final = unmasking()
-    print("[Server] sum_xu: ", final)
+    print("[Server] average of sum_xu): ", final)

--- a/server/BasicSAServer.py
+++ b/server/BasicSAServer.py
@@ -3,6 +3,7 @@ sys.path.append(os.path.dirname(os.path.abspath(os.path.dirname(__file__))))
 
 from MainServer import MainServer
 from BasicSA import getCommonValues, reconstructPuv, reconstructPu
+from CommonValue import BasicSARound
 
 users = {}
 totalNum = 4
@@ -10,14 +11,18 @@ yu = 0
 
 # broadcast common value
 def setUp():
-    server = MainServer('ServerSetUp', 7000)
+    tag = BasicSARound.SetUp.name
+    port = BasicSARound.SetUp.value
+    server = MainServer(tag, port)
     server.start()
 
     commonValues = getCommonValues()
     server.broadcast(commonValues)
 
 def advertiseKeys():
-    server = MainServer('AdvertiseKeys', 7010)
+    tag = BasicSARound.AdvertiseKeys.name
+    port = BasicSARound.AdvertiseKeys.value
+    server = MainServer(tag, port)
     server.start()
 
     # requests example: {"c_pk":"VALUE", "s_pk": "VALUE"}
@@ -41,7 +46,9 @@ def advertiseKeys():
 
 
 def shareKeys():
-    server = MainServer('ShareKeys', 7020)
+    tag = BasicSARound.ShareKeys.name
+    port = BasicSARound.ShareKeys.value
+    server = MainServer(tag, port)
     server.start()
 
     # (one) request example: [ 0, (0, 0, e00), (0, 1, e01) ... ]
@@ -68,7 +75,9 @@ def shareKeys():
     server.foreach(response)
     
 def MaskedInputCollection():
-    server = MainServer('MaskedInputCollection', 7030)
+    tag = BasicSARound.MaskedInputCollection.name
+    port = BasicSARound.MaskedInputCollection.value
+    server = MainServer(tag, port)
     server.start()
 
     # if u3 dropped
@@ -85,7 +94,9 @@ def MaskedInputCollection():
     server.broadcast(response)
 
 def Unmasking():
-    server = MainServer('Unmasking', 7040)
+    tag = BasicSARound.Unmasking.name
+    port = BasicSARound.Unmasking.value
+    server = MainServer(tag, port)
     server.start()
 
     # if u2, u3 dropped

--- a/server/BasicSAServer.py
+++ b/server/BasicSAServer.py
@@ -45,30 +45,29 @@ def shareKeys():
     server = MainServer(tag, port)
     server.start()
 
-    # (one) request example: [ 0, (0, 0, e00), (0, 1, e01) ... ]
-    # requests example: [ [ 0, (0, 0, e00), ... ], [ 1, (1, 0, e10), ... ], ... ]
+    # (one) request example: {0: [(0, 0, e00), (0, 1, e01) ... ]}
+    # requests example: [{0: [(0, 0, e00), ... ]}, {1: [(1, 0, e10), ... ]}, ... ]
     requests = server.requests
 
     # response example: { 0: [e00, e10, e20, ...], 1: [e01, e11, e21, ... ] ... }
     response = {}
+    requests_euv = []
     for request in requests:
         requestData = request[1]  # (socket, data)
-        idx = requestData[0]
-        response[idx] = []  # make list
-    for request in requests:
-        requestData = request[1]  # (socket, data)
-        for i, data in enumerate(requestData):
-            if i == 0:
-                continue
-            (u, v, euv) = data
+        for idx, data in requestData.items(): #only one
+            response[idx] = {}  # make dic
+            requests_euv.append(data)
+    for request in requests_euv:
+        for (u, v, euv) in request:
             try:
-                response[v].append(euv)
+                response[str(v)][u] = euv
             except KeyError:  # drop-out # TODO save U2
+                print("KeyError")
                 pass
 
     server.foreach(response)
     
-def MaskedInputCollection():
+def maskedInputCollection():
     tag = BasicSARound.MaskedInputCollection.name
     port = BasicSARound.MaskedInputCollection.value
     server = MainServer(tag, port)
@@ -87,7 +86,7 @@ def MaskedInputCollection():
 
     server.broadcast(response)
 
-def Unmasking():
+def unmasking():
     tag = BasicSARound.Unmasking.name
     port = BasicSARound.Unmasking.value
     server = MainServer(tag, port)

--- a/server/MainServer.py
+++ b/server/MainServer.py
@@ -41,6 +41,8 @@ class MainServer:
                         print(requestData)
                         print(self.tag)
                         raise AttributeError
+                    else:
+                        requestData.pop('request')
                     
                     print(f'[{self.tag}] Client: {addr}')
                     print(f'[{self.tag}] Client request: {request}')

--- a/server/MainServer.py
+++ b/server/MainServer.py
@@ -8,8 +8,8 @@ class MainServer:
     port = 20
     SIZE = 2048
     ENCODING = 'ascii'
-    t = 3 # threshold
-    interval = 20 # server waits in one round # second
+    t = 1 # threshold
+    interval = 10 # server waits in one round # second
     timeout = 10 #temp
 
     userNum = 0
@@ -26,7 +26,7 @@ class MainServer:
             s.bind((self.host, self.port))
             s.settimeout(self.timeout)
             s.listen()
-            print('[{0}] Server started'.format(self.tag))
+            print(f'[{self.tag}] Server started')
 
             while (self.endTime - self.startTime) < self.interval:
                 currentClient = socket
@@ -42,19 +42,19 @@ class MainServer:
                         print(self.tag)
                         raise AttributeError
                     
-                    print('[{0}] Client: {1}'.format(self.tag, addr))
-                    print('[{0}] Client request: {1}'.format(self.tag, request))
+                    print(f'[{self.tag}] Client: {addr}')
+                    print(f'[{self.tag}] Client request: {request}')
 
                     self.userNum = self.userNum + 1
                     self.requests.append((clientSocket, requestData))
                 except socket.timeout:
                     pass
                 except AttributeError:
-                    print('[{0}] Exception: invalid request at {0}'.format(self.tag))
-                    currentClient.sendall(bytes('Exception: invalid request at {0}'.format(self.tag), self.ENCODING))
+                    print(f'[{self.tag}] Exception: invalid request at {self.tag}')
+                    currentClient.sendall(bytes(f'Exception: invalid request at {self.tag}', self.ENCODING))
                     pass
                 except:
-                    print('[{0}] Exception: invalid request or unknown server error'.format(self.tag))
+                    print(f'[{self.tag}] Exception: invalid request or unknown server error')
                     currentClient.sendall(bytes('Exception: invalid request or unknown server error', self.ENCODING))
                     pass
                 
@@ -62,8 +62,8 @@ class MainServer:
 
         # check threshold
         if self.t > self.userNum:
-            print('[{0}] Exception: insufficient {1} users with {2} threshold'.format(self.tag, self.userNum, self.t))
-            raise Exception("Need at least {0} users, but only {1} user(s) responsed".format(self.t, self.userNum))
+            print(f'[{self.tag}] Exception: insufficient {self.userNum} users with {self.t} threshold')
+            raise Exception(f"Need at least {self.t} users, but only {self.userNum} user(s) responsed")
     
     # broadcast to all client (same response)
     def broadcast(self, response): # send response (broadcast)
@@ -73,7 +73,7 @@ class MainServer:
             clientSocket.sendall(bytes(response_json, self.ENCODING))
         
         self.serverSocket.close()
-        print('[{0}] Server finished'.format(self.tag))
+        print(f'[{self.tag}] Server finished')
     
     # send response for each client (different response)
     def foreach(self, response):
@@ -85,4 +85,4 @@ class MainServer:
             clientSocket.sendall(bytes(response_json, self.ENCODING))
         
         self.serverSocket.close()
-        print('[{0}] Server finished'.format(self.tag))
+        print(f'[{self.tag}] Server finished')

--- a/server/MainServer.py
+++ b/server/MainServer.py
@@ -9,8 +9,8 @@ class MainServer:
     SIZE = 2048
     ENCODING = 'ascii'
     t = 1 # threshold
-    interval = 10 # server waits in one round # second
-    timeout = 10 #temp
+    interval = 5 # server waits in one round # second
+    timeout = 3 #temp
 
     userNum = 0
     requests = []
@@ -20,6 +20,7 @@ class MainServer:
         self.port = port
 
     def start(self):
+        self.requests = []
         self.startTime = self.endTime = time.time()
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             self.serverSocket = s
@@ -80,9 +81,11 @@ class MainServer:
     # send response for each client (different response)
     def foreach(self, response):
         # 'response' must be: { index: [response], ... }
-        # 'requestData' must be: [ index, [...data] ... ]
+        # 'requestData' must be: { index: [...data], ... }
         for (clientSocket, requestData) in self.requests:
-            idx = requestData[0]
+            idx = 0
+            for data in requestData.keys():
+                idx = data
             response_json = json.dumps(response[idx])
             clientSocket.sendall(bytes(response_json, self.ENCODING))
         

--- a/server/MainServer.py
+++ b/server/MainServer.py
@@ -7,7 +7,7 @@ class MainServer:
     host = 'localhost'
     port = 20
     SIZE = 2048
-    ENCODING = 'ascii'
+    ENCODING = 'utf-8'
     t = 1 # threshold
     interval = 5 # server waits in one round # second
     timeout = 3 #temp

--- a/server/MainServer.py
+++ b/server/MainServer.py
@@ -1,3 +1,4 @@
+from http import client
 import socket
 import json
 import time
@@ -5,10 +6,10 @@ import time
 class MainServer:
     host = 'localhost'
     port = 20
-    SIZE = 1024
+    SIZE = 2048
     ENCODING = 'ascii'
-    t = 0 # threshold #temp
-    interval = 10 # server waits in one round # second
+    t = 3 # threshold
+    interval = 20 # server waits in one round # second
     timeout = 10 #temp
 
     userNum = 0
@@ -28,16 +29,33 @@ class MainServer:
             print('[{0}] Server started'.format(self.tag))
 
             while (self.endTime - self.startTime) < self.interval:
+                currentClient = socket
                 try:
                     clientSocket, addr = s.accept()
+                    currentClient = clientSocket
+
                     request = str(clientSocket.recv(self.SIZE), self.ENCODING)  # receive client data
+                    requestData = json.loads(request)
+                    if requestData['request'] != self.tag: # check request
+                        # request must contain {request: tag}
+                        print(requestData)
+                        print(self.tag)
+                        raise AttributeError
+                    
                     print('[{0}] Client: {1}'.format(self.tag, addr))
                     print('[{0}] Client request: {1}'.format(self.tag, request))
-                    self.userNum = self.userNum + 1
 
-                    requestData = json.loads(request)
+                    self.userNum = self.userNum + 1
                     self.requests.append((clientSocket, requestData))
                 except socket.timeout:
+                    pass
+                except AttributeError:
+                    print('[{0}] Exception: invalid request at {0}'.format(self.tag))
+                    currentClient.sendall(bytes('Exception: invalid request at {0}'.format(self.tag), self.ENCODING))
+                    pass
+                except:
+                    print('[{0}] Exception: invalid request or unknown server error'.format(self.tag))
+                    currentClient.sendall(bytes('Exception: invalid request or unknown server error', self.ENCODING))
                     pass
                 
                 self.endTime = time.time()

--- a/server/gui.py
+++ b/server/gui.py
@@ -5,8 +5,8 @@ root = Tk()
 root.title("Server")
 root.geometry("640x400+100+100")
 
-SARound = ["SetUp", "AdvertiseKeys", "ShareKeys"]
-func = [BasicSAServer.setUp, BasicSAServer.advertiseKeys, BasicSAServer.shareKeys]
+SARound = ["SetUp", "AdvertiseKeys", "ShareKeys", "MaskedInputCollection", "Unmasking"]
+func = [BasicSAServer.setUp, BasicSAServer.advertiseKeys, BasicSAServer.shareKeys, BasicSAServer.maskedInputCollection, BasicSAServer.unmasking]
 btn = []
 
 for i, round in enumerate(SARound):


### PR DESCRIPTION
## 개요
- server-client 내용, secure protocol 내용 수정 및 추가

## 작업사항
- BasicSA 에 대해 common value 를 정의해두고 사용하도록 했습니다. (tag:port)
- server 는 `tag` 로 client 의 요청이 현재 round 에 맞는지 검증합니다.
- client 는 class 형태로 수정하고, send/receive 를 해주는 함수를 만들어 매 round 마다 이를 공통적으로 사용하도록 했습니다.
- server 와 client 의 오류 사항이나 서로 맞지 않는 사항을 전반적으로 수정했습니다. (눈 빠질 뻔..)
- secure protocol: 
  - `g`, `p` 값을 파일 내에서 선언하여 사용하던 것을 함수 매개변수로 바꿨습니다. 
  (`g`, `p` 생성해주는 함수는 이후 반영 예정, 현재는 `g=3`, `p=7` 로 사용)
  - 논문에 따라, agree 결과에 hash 함수를 적용하고, AES algorithm 을 사용하는 것으로 바꿨습니다.
  : 암복호화 알고리즘은 `AES-128` (mode: CBC),  hash 함수는 `MD5` 사용 -> 128 bit key
  (논문에서는 GCM mode 로 했던데 저는 일단 CBC 로 했습니다)

## 확인할 사항
- Crypto 관련 패키지 (아마 pycryptodome 이나 pycrypto) 를 설치해주세요.

## 실행 결과
3명의 client 로 전체가 drop-out 하지 않고 실행할 경우와, 한 client 가 `ShareKeys` 에서 drop-out 하는 경우에 대해 테스트를 완료했고, log 를 기록해두었습니다. 여기서는 server 의 로그만 이미지로 캡쳐하여 첨부합니다. (필요하다면 전체 로그를 보여드리도록 하겠습니다!).
현재 client 의 `xu` 가 모두 0 이므로, server 에서 unmasking 까지 하고 난 후 얻은 `sum_xu` 값이 0 임을 확인했습니다.
- 3명의 client 전체가 drop-out 하지 않는 경우
  ![image](https://user-images.githubusercontent.com/63097207/152686407-f55f996a-245b-4478-8af2-48372a81e710.png)
- client 1 이 drop-out 하는 경우
  ![image](https://user-images.githubusercontent.com/63097207/152686433-db32a6bf-22b5-423c-b305-6edc1d0f7fb7.png)