### PR TITLE
Turbo: fix setup

### DIFF
--- a/client/TurboClient.py
+++ b/client/TurboClient.py
@@ -43,13 +43,15 @@ class TurboClient:
         PORT = TurboRound.Turbo.value
 
         request = {"group": self.group, "index": self.index}
-        # response = {"maskedxij": {}, "encodedxij": {}, "si": {}, "codedsi": {}}
+        # response = {"maskedxij": {}, "encodedxij": {}, "si": {}, "codedsi": {}, "perGroup": 0, "mask_u": 0}
         response = sendRequestAndReceive(self.HOST, PORT, tag, request)
 
         self.maskedxij = response["maskedxij"]
         self.encodedxij = response["encodedxij"]
         self.si = response["si"]
         self.codedsi = response["codedsi"]
+        self.perGroup = response["perGroup"]
+        self.mask_u = response["mask_u"]
         print(response)
         print(self.maskedxij, self.encodedxij, self.si, self.codedsi)
     

--- a/server/TurboServer.py
+++ b/server/TurboServer.py
@@ -12,10 +12,11 @@ usersNum = 0
 threshold = 0
 R = 0
 groups = []
+mask_u_list = []
 
 # send common values and index, group of each user
 def setUp():
-    global groupNum, usersNum, threshold, R, groups, perGroup
+    global groupNum, usersNum, threshold, R, groups, perGroup, mask_u_list
 
     tag = TurboRound.SetUp.name
     port = TurboRound.SetUp.value
@@ -38,7 +39,9 @@ def setUp():
             response_ij = copy.deepcopy(commonValues)
             response_ij["group"] = i
             response_ij["index"] = j
-            response_ij["mask_u"] = random.randrange(1, R) # 1~R
+            mask_u = random.randrange(1, R) # 1~R
+            mask_u_list.append(mask_u)
+            response_ij["mask_u"] = mask_u
             response.append(response_ij)
     server.foreachIndex(response)
 
@@ -54,6 +57,8 @@ def turbo():
     server.start()
 
 def final():
+    global mask_u_list
+
     tag = TurboRound.Final.name
     port = TurboRound.Final.value
 
@@ -68,8 +73,7 @@ def final():
         final_barS.append(int(requestData["final_barS"]))
     server.broadcast({})
 
-    print(final_tildeS)
-    print(final_barS)
+    return sum(final_tildeS) / len(final_tildeS) - sum(mask_u_list)
 
 if __name__ == "__main__":
     setUp()

--- a/server/TurboServer.py
+++ b/server/TurboServer.py
@@ -7,6 +7,7 @@ from BasicSA import getCommonValues
 from CommonValue import TurboRound
 
 groupNum = 0
+perGroup = 0
 usersNum = 0
 threshold = 0
 R = 0
@@ -14,7 +15,7 @@ groups = []
 
 # send common values and index, group of each user
 def setUp():
-    global groupNum, usersNum, threshold, R, groups
+    global groupNum, usersNum, threshold, R, groups, perGroup
 
     tag = TurboRound.SetUp.name
     port = TurboRound.SetUp.value
@@ -42,14 +43,14 @@ def setUp():
     server.foreachIndex(response)
 
 def turbo():
-    global groups, usersNum
+    global groups, usersNum, perGroup
 
     tag = TurboRound.Turbo.name
     tag_value = TurboRound.TurboValue.name
     tag_final = TurboRound.TurboFinal.name
     port = TurboRound.Turbo.value
     
-    server = TurboBaseServer(tag, tag_value, tag_final, port, 3, usersNum) # len(groups)
+    server = TurboBaseServer(tag, tag_value, tag_final, port, 3, usersNum, perGroup) # len(groups)
     server.start()
 
 def final():

--- a/server/TurboServer.py
+++ b/server/TurboServer.py
@@ -6,6 +6,7 @@ from TurboBaseServer import TurboBaseServer
 from BasicSA import getCommonValues
 from CommonValue import TurboRound
 
+groupNum = 0
 usersNum = 0
 threshold = 0
 R = 0
@@ -13,7 +14,7 @@ groups = []
 
 # send common values and index, group of each user
 def setUp():
-    global usersNum, threshold, R, groups
+    global groupNum, usersNum, threshold, R, groups
 
     tag = TurboRound.SetUp.name
     port = TurboRound.SetUp.value
@@ -24,14 +25,17 @@ def setUp():
     usersNum = commonValues["n"]
     threshold = commonValues["t"]
     R = commonValues["R"]
+    perGroup = 2 # temp
 
-    usersNow = len(server.requests)
+    usersNow = len(server.requests) # MUST be multiple of perGroup
+    groupNum = int(usersNow / perGroup)
     response = []
-    for i in range(usersNow):
-        response_i = copy.deepcopy(commonValues)
-        response_i["group"] = i # TODO: grouping
-        response_i["index"] = 0 # TODO
-        response.append(response_i)
+    for i in range(groupNum):
+        for j in range(perGroup):
+            response_ij = copy.deepcopy(commonValues)
+            response_ij["group"] = i
+            response_ij["index"] = j
+            response.append(response_ij)
     server.foreachIndex(response)
 
 def turbo():

--- a/server/TurboServer.py
+++ b/server/TurboServer.py
@@ -1,4 +1,4 @@
-import os, sys, copy
+import os, sys, copy, random
 sys.path.append(os.path.dirname(os.path.abspath(os.path.dirname(__file__))))
 
 from MainServer import MainServer
@@ -25,7 +25,9 @@ def setUp():
     usersNum = commonValues["n"]
     threshold = commonValues["t"]
     R = commonValues["R"]
+
     perGroup = 2 # temp
+    commonValues["perGroup"] = perGroup
 
     usersNow = len(server.requests) # MUST be multiple of perGroup
     groupNum = int(usersNow / perGroup)
@@ -35,6 +37,7 @@ def setUp():
             response_ij = copy.deepcopy(commonValues)
             response_ij["group"] = i
             response_ij["index"] = j
+            response_ij["mask_u"] = random.randrange(1, R) # 1~R
             response.append(response_ij)
     server.foreachIndex(response)
 


### PR DESCRIPTION
## 개요
- Turbo 에 setup 수정

## 작업사항
- Turbo Server 에서 setup 에서 grouping 하는 과정 추가
  - 현재는 각 그룹의 구성원 수가 동일한 것을 가정함 (딱 나누어 떨어진다고 가정)
  - 각 그룹 내에서 사용자의 index 는 0 부터 시작
- setup 에서 서버가 `mask u` 값과 `perGroup` (한 그룹의 구성원 수) 값을 넘겨주는 것 추가

## 확인할 사항
