### PR TITLE
Flatten weights and restore

### DIFF
--- a/Brea.py
+++ b/Brea.py
@@ -1,6 +1,7 @@
 import random
 import numpy as np
 import learning.federated_main as fl
+import learning.models_helper as mhelper
 
 # make N theta_i
 # [호출] : 서버
@@ -100,7 +101,7 @@ def calculate_distance(shares1, shares2):
 
 if __name__ == "__main__":
     model = fl.setup()
-    model_weights_list = fl.weights_to_dic_of_list(model.state_dict())
+    model_weights_list = mhelper.weights_to_dic_of_list(model.state_dict())
     # ww = np.array(model_weights_list[0])
     # print(model_weights_list)
     w1 = 100

--- a/client/BasicSAClient.py
+++ b/client/BasicSAClient.py
@@ -3,6 +3,7 @@ sys.path.append(os.path.dirname(os.path.abspath(os.path.dirname(__file__))))
 import BasicSA as sa
 from CommonValue import BasicSARound
 import learning.federated_main as fl
+import learning.models_helper as mhelper
 
 SIZE = 2048
 ENCODING = 'utf-8'
@@ -67,7 +68,7 @@ class BasicSAClient:
         self.commonValues = response
         self.u = response["index"]
         self.data = response["data"] # user_groups[idx]
-        global_weights = fl.dic_of_list_to_weights(response["weights"])
+        global_weights = mhelper.dic_of_list_to_weights(response["weights"])
 
         if self.model == {}:
             self.model = fl.setup()
@@ -140,7 +141,7 @@ class BasicSAClient:
             s_pk_dic, 
             self.commonValues["R"])
         
-        request = {"idx": self.u, "yu": fl.weights_to_dic_of_list(yu)}  # request example: {"idx":0, "yu":y0}
+        request = {"idx": self.u, "yu": mhelper.weights_to_dic_of_list(yu)}  # request example: {"idx":0, "yu":y0}
 
         # receive sending_yu_list from server
         response = sendRequestAndReceive(self.HOST, self.PORT, tag, request)

--- a/learning/federated_main.py
+++ b/learning/federated_main.py
@@ -117,7 +117,7 @@ def dic_of_list_to_weights(dic_weights):
     #model.load_state_dict(params)
     return params
 
-def flatten_tensor_to_list(weights):
+def flatten_tensor(weights):
     """ flatten tensor weights into a one-dimensional list
     Args:
         weights (dict): model weights (model.state_dict())
@@ -147,6 +147,39 @@ def restore_weights_tensor(weights_info, flatten_weights):
         next = prev + shape.numel()
         layer_tensor = torch.Tensor(flatten_weights[prev:next]).reshape(shape)
         new_weights[layer] = layer_tensor
+        prev = next
+    return new_weights
+
+def flatten_list(weights):
+    """ flatten list of weights into a one-dimensional list
+    Args:
+        weights (dict): model weights (key: layer name, value: list (:NOT TENSOR))
+    Returns:
+        dict: weights shape information (key: layer name, value: shape)
+        list: one-dimensional list
+    """
+    weights_info = {}
+    flatten_weights = []
+    for layer, item in weights.items():
+        weights_info[layer] = torch.Tensor(item).shape
+        flatten_weights = flatten_weights + list(deepflatten(item))
+    return weights_info, flatten_weights
+
+def restore_weights_list(weights_info, flatten_weights):
+    """ restore list of weights from a one-dimensional list
+    Args:
+        weights_info (dict): weights shape information
+        flatten_weights (list): one-dimensional list of original weights
+    Returns:
+        dict: model weights(tensor) (model.state_dict())
+    """
+    new_weights = {}
+    prev = 0
+    next = 0
+    for layer, shape in weights_info.items():
+        next = prev + shape.numel()
+        layer_list = torch.Tensor(flatten_weights[prev:next]).reshape(shape).tolist()
+        new_weights[layer] = layer_list
         prev = next
     return new_weights
 

--- a/learning/federated_main.py
+++ b/learning/federated_main.py
@@ -7,7 +7,6 @@ from .options import args_parser
 from .update import LocalUpdate, test_inference
 from .models import CNNMnist
 from .utils import get_mnist_train, get_mnist_test, get_users_data, average_weights, exp_details
-from iteration_utilities import deepflatten
 
 # 전역변수 선언
 train_loss, train_accuracy, train_dataset = [], [], []
@@ -94,95 +93,6 @@ def update_globalmodel(global_model, local_weight_sum):
 
 def update_model(model, weights):
     model.load_state_dict(weights)
-
-def get_model_weights(model):
-    return model.state_dict()
-
-def weights_to_dic_of_list(weights):
-    dic_weights = {}
-    for param_tensor, value in weights.items():
-        dic_weights[param_tensor] = value.tolist()
-    return dic_weights
-
-# list to tensor, dic
-# returns new weights of model
-def dic_of_list_to_weights(dic_weights):
-    global args
-    params = {}
-    for param_tensor, value in dic_weights.items():
-        if args.gpu: # cuda
-            params[param_tensor] = torch.Tensor(value).cuda()
-        else: # cpu
-            params[param_tensor] = torch.Tensor(value).cpu()
-    #model.load_state_dict(params)
-    return params
-
-def flatten_tensor(weights):
-    """ flatten tensor weights into a one-dimensional list
-    Args:
-        weights (dict): model weights (model.state_dict())
-    Returns:
-        dict: weights shape information (key: layer name, value: shape)
-        list: one-dimensional list
-    """
-    weights_info = {}
-    flatten_weights = []
-    for layer, item in weights.items():
-        weights_info[layer] = item.shape
-        flatten_weights = flatten_weights + list(deepflatten(item.tolist()))
-    return weights_info, flatten_weights
-
-def restore_weights_tensor(weights_info, flatten_weights):
-    """ restore tensor weights from a one-dimensional list
-    Args:
-        weights_info (dict): weights shape information
-        flatten_weights (list): one-dimensional list of original weights
-    Returns:
-        dict: model weights(tensor) (model.state_dict())
-    """
-    new_weights = {}
-    prev = 0
-    next = 0
-    for layer, shape in weights_info.items():
-        next = prev + shape.numel()
-        layer_tensor = torch.Tensor(flatten_weights[prev:next]).reshape(shape)
-        new_weights[layer] = layer_tensor
-        prev = next
-    return new_weights
-
-def flatten_list(weights):
-    """ flatten list of weights into a one-dimensional list
-    Args:
-        weights (dict): model weights (key: layer name, value: list (:NOT TENSOR))
-    Returns:
-        dict: weights shape information (key: layer name, value: shape)
-        list: one-dimensional list
-    """
-    weights_info = {}
-    flatten_weights = []
-    for layer, item in weights.items():
-        weights_info[layer] = torch.Tensor(item).shape
-        flatten_weights = flatten_weights + list(deepflatten(item))
-    return weights_info, flatten_weights
-
-def restore_weights_list(weights_info, flatten_weights):
-    """ restore list of weights from a one-dimensional list
-    Args:
-        weights_info (dict): weights shape information
-        flatten_weights (list): one-dimensional list of original weights
-    Returns:
-        dict: model weights(tensor) (model.state_dict())
-    """
-    new_weights = {}
-    prev = 0
-    next = 0
-    for layer, shape in weights_info.items():
-        next = prev + shape.numel()
-        layer_list = torch.Tensor(flatten_weights[prev:next]).reshape(shape).tolist()
-        new_weights[layer] = layer_list
-        prev = next
-    return new_weights
-
 
 # 서버는 전달받은 update된 global model을 클라이언트들에게 전송
 

--- a/learning/models_helper.py
+++ b/learning/models_helper.py
@@ -1,0 +1,90 @@
+import torch
+from iteration_utilities import deepflatten
+
+def get_model_weights(model):
+    return model.state_dict()
+
+def weights_to_dic_of_list(weights):
+    dic_weights = {}
+    for param_tensor, value in weights.items():
+        dic_weights[param_tensor] = value.tolist()
+    return dic_weights
+
+# list to tensor, dic
+# returns new weights of model
+def dic_of_list_to_weights(dic_weights):
+    global args
+    params = {}
+    for param_tensor, value in dic_weights.items():
+        if args.gpu: # cuda
+            params[param_tensor] = torch.Tensor(value).cuda()
+        else: # cpu
+            params[param_tensor] = torch.Tensor(value).cpu()
+    #model.load_state_dict(params)
+    return params
+
+def flatten_tensor(weights):
+    """ flatten tensor weights into a one-dimensional list
+    Args:
+        weights (dict): model weights (model.state_dict())
+    Returns:
+        dict: weights shape information (key: layer name, value: shape)
+        list: one-dimensional list
+    """
+    weights_info = {}
+    flatten_weights = []
+    for layer, item in weights.items():
+        weights_info[layer] = item.shape
+        flatten_weights = flatten_weights + list(deepflatten(item.tolist()))
+    return weights_info, flatten_weights
+
+def restore_weights_tensor(weights_info, flatten_weights):
+    """ restore tensor weights from a one-dimensional list
+    Args:
+        weights_info (dict): weights shape information
+        flatten_weights (list): one-dimensional list of original weights
+    Returns:
+        dict: model weights(tensor) (model.state_dict())
+    """
+    new_weights = {}
+    prev = 0
+    next = 0
+    for layer, shape in weights_info.items():
+        next = prev + shape.numel()
+        layer_tensor = torch.Tensor(flatten_weights[prev:next]).reshape(shape)
+        new_weights[layer] = layer_tensor
+        prev = next
+    return new_weights
+
+def flatten_list(weights):
+    """ flatten list of weights into a one-dimensional list
+    Args:
+        weights (dict): model weights (key: layer name, value: list (:NOT TENSOR))
+    Returns:
+        dict: weights shape information (key: layer name, value: shape)
+        list: one-dimensional list
+    """
+    weights_info = {}
+    flatten_weights = []
+    for layer, item in weights.items():
+        weights_info[layer] = torch.Tensor(item).shape
+        flatten_weights = flatten_weights + list(deepflatten(item))
+    return weights_info, flatten_weights
+
+def restore_weights_list(weights_info, flatten_weights):
+    """ restore list of weights from a one-dimensional list
+    Args:
+        weights_info (dict): weights shape information
+        flatten_weights (list): one-dimensional list of original weights
+    Returns:
+        dict: model weights(tensor) (model.state_dict())
+    """
+    new_weights = {}
+    prev = 0
+    next = 0
+    for layer, shape in weights_info.items():
+        next = prev + shape.numel()
+        layer_list = torch.Tensor(flatten_weights[prev:next]).reshape(shape).tolist()
+        new_weights[layer] = layer_list
+        prev = next
+    return new_weights

--- a/learning/testcode.py
+++ b/learning/testcode.py
@@ -1,7 +1,8 @@
 import copy
 from tqdm import tqdm
 
-from federated_main import add_accuracy, setup, get_user_dataset, get_model_weights, local_update, test_accuracy, update_globalmodel, test_model
+from federated_main import add_accuracy, setup, get_user_dataset, local_update, test_accuracy, update_globalmodel, test_model
+from models_helper import get_model_weights
 from utils import sum_weights
 
 if __name__ == "__main__":

--- a/server/BasicSAServer.py
+++ b/server/BasicSAServer.py
@@ -6,6 +6,7 @@ from BasicSA import getCommonValues, reconstructPvu, reconstructPu, reconstruct,
 from CommonValue import BasicSARound
 from ast import literal_eval
 import learning.federated_main as fl
+import learning.models_helper as mhelper
 import SecureProtocol as sp
 
 model = {}
@@ -38,7 +39,7 @@ def setUp():
 
     if model == {}:
         model = fl.setup()
-    model_weights_list = fl.weights_to_dic_of_list(model.state_dict())
+    model_weights_list = mhelper.weights_to_dic_of_list(model.state_dict())
     user_groups = fl.get_user_dataset(usersNow)
 
     response = []
@@ -122,7 +123,7 @@ def maskedInputCollection():
     for request in requests:
         requestData = request[1]  # (socket, data)
         response.append(int(requestData["idx"]))
-        yu_ = fl.dic_of_list_to_weights(requestData["yu"])
+        yu_ = mhelper.dic_of_list_to_weights(requestData["yu"])
         yu_list.append(yu_)
 
     server.broadcast({"users": response})

--- a/server/BasicSAServerV2.py
+++ b/server/BasicSAServerV2.py
@@ -7,6 +7,7 @@ from BasicSA import getCommonValues, reconstructPvu, reconstructPu, reconstruct,
 from CommonValue import BasicSARound
 from ast import literal_eval
 import learning.federated_main as fl
+import learning.models_helper as mhelper
 import SecureProtocol as sp
 
 class BasicSAServerV2:
@@ -137,7 +138,7 @@ class BasicSAServerV2:
 
         if self.model == {}:
             self.model = fl.setup()
-        model_weights_list = fl.weights_to_dic_of_list(self.model.state_dict())
+        model_weights_list = mhelper.weights_to_dic_of_list(self.model.state_dict())
         user_groups = fl.get_user_dataset(self.n)
 
         for idx, (clientSocket, requestData) in enumerate(requests):
@@ -192,7 +193,7 @@ class BasicSAServerV2:
         for request in requests:
             requestData = request[1]  # (socket, data)
             response.append(int(requestData["idx"]))
-            yu_ = fl.dic_of_list_to_weights(requestData["yu"])
+            yu_ = mhelper.dic_of_list_to_weights(requestData["yu"])
             self.yu_list.append(yu_)
 
         self.broadcast(requests, {"users": response})


### PR DESCRIPTION
## 개요
- model weights 값을 1차원 리스트로 변형하고 다시 (기존 형태의) dictionary 로 돌려주는 helper 함수들 구현
- model 에 관한 helper 함수들 위치 변경

## 작업사항
두 가지 방향으로 위의 기능을 지원하는 함수를 구현했습니다.
기본적으로 `model.state_dict()` 의 결과값인 tensor 로 구성된 weights dictionary 를 이용하는 함수와, (`weights_to_dic_of_list()` 등으로) tensor 가 아닌 list 의 dictionary 형태인 경우에 사용할 수 있는 부가적인 함수를 구현했습니다. (잘 작동함을 확인했습니다.)
__두 경우 모두 각 layer 별로 1차원 리스트를 만드는 것이 아닌, 전체 weights 를 1차원으로 만드는 형태입니다.__
- `flatten_tensor()` / `restore_weights_tensor()`: 
tensor 로 구성된 weights dictionary 를 1차원 list 로 변형하고 이를 다시 되돌려주는 함수
- `flatten_list()` / `restore_weights_list()`: 
list 로 구성된 weights dictionary 를 1차원 list 로 변형하고 이를 다시 되돌려주는 함수
  - 이는 현재 네트워크 전송을 위해 tensor 가 아닌 list 형태로 작업하는 부분이 많아서 이를 고려하여 추가로 구현한 것인데, 함수만으로 본다면 둘 중 위 함수가 더 효율적이긴 합니다.

또한, learning 외로 model weights 에 대한 조작이 필요한 함수들은 `/learning/models_helper.py` 로 옮겼고, 기존의 코드를 참고하고 있는 함수들은 변경 완료했습니다. 다만, 이후에 사용하거나 현 `master` 브랜치 외로 작업한 내용에 대해서는 추후 코드 병합 시 이를 유의해주시기 바랍니다.

## 확인할 사항
- `iteration_utilities` 를 추가했습니다. 설치 후 사용해주세요.

## 사용 방법
사용 방법에 관한 짧은 코드 설명입니다.
1. tensor 계열 함수 사용 시
```
weights_info, flatten_weights = models_helper.flatten_tensor(model.state_dict())
restored_weights = models_helper.restore_weights_tensor(weights_info, flatten_weights)
```
2. list 계열 함수 사용 시
```
weights = models_helper.weights_to_dic_of_list(model.state_dict())
weights_info, flatten_weights = models_helper.flatten_list(weights)
restored_weights = models_helper.restore_weights_list(weights_info, flatten_weights)
```