### PR TITLE
Hetero/learning: add local learning and split weights

### DIFF
--- a/BasicSA.py
+++ b/BasicSA.py
@@ -73,7 +73,7 @@ def generateMaskedInput(u, bu, xu, s_sk, euv_list, s_pk_dic, R):
 
 # users_previous [list]: users who were alive in the previous round
 # users_last [list]: users who were alive in the recent round
-def unmasking(u, c_sk, euv_dic, c_pk_dic, users_previous, users_last, R):
+def unmasking(u, c_sk, euv_dic, c_pk_dic, users_previous, users_last):
     global p
 
     s_sk_shares_dic = {}

--- a/HeteroSAg.py
+++ b/HeteroSAg.py
@@ -58,7 +58,7 @@ def getSegmentInfoFromB(B, G, perGroup):
     print(f'segment: {segment_info}')
     return segment_info
 
-def generateMaskedInputOfSegments(index, bu, xu, s_sk, B, G, group, perGroup, euv_list, s_pk_dic, p, R):
+def generateMaskedInputOfSegments(index, bu, xu, s_sk, B, G, group, perGroup, weights_interval, euv_list, s_pk_dic, p, R):
     """ generate masked input of segments
     Args:
         index (int): user's index
@@ -69,6 +69,7 @@ def generateMaskedInputOfSegments(index, bu, xu, s_sk, B, G, group, perGroup, eu
         G (int): # of group
         group (int): user's group
         perGroup (int): users num of one group
+        weights_interval (list): interval index of weights (for each segment)
         euv_list (list): user's evu_list
         s_pk_dic (dict): other's public key s dictionary (key: index, value: s_pk)
         p (int): prime
@@ -89,10 +90,12 @@ def generateMaskedInputOfSegments(index, bu, xu, s_sk, B, G, group, perGroup, eu
     print(f'pu: {pu}')
 
     # compute p_uv
+    weights_info, flatten_xu = mhelper.flatten_tensor(xu)
+    segment_xu = list(map(lambda i: flatten_xu[weights_interval[i]:weights_interval[i+1]], range(0, G)))
     segment_yu = {i: {} for i in range(G)}
     for l, segment in enumerate(B): # for each segment
 
-        # find group of same segment
+        # find group of same level
         q = segment[group]
         p_uv_list = []
         for i, value in enumerate(segment):
@@ -114,8 +117,7 @@ def generateMaskedInputOfSegments(index, bu, xu, s_sk, B, G, group, perGroup, eu
 
         # generate yu (masked xu) of segment l
         mask = pu + sum(p_uv_list)
-        masked_yu = add_to_weights(xu, mask)
-        segment_yu[l][q] = mhelper.weights_to_dic_of_list(masked_yu)
+        segment_yu[l][q] = list(map(lambda x : x + mask, segment_xu[l]))
     
     return segment_yu
 
@@ -147,7 +149,7 @@ def unmasking(segment_info, G, segment_yu, surviving_users, users_keys, s_sk_dic
     Args:
         segment_info (dict): segment info (key: segment index, value: dict (key: quantization level, value: index list))
         G (int): # of group
-        segment_yu (dict): yu of segments (key: segment level, value: dict(key: quantization level, value: list of yu))
+        segment_yu (dict): yu of segments (key: segment level, value: dict(key: quantization level, value: segment list of yu))
         surviving_users (list): surviving users index list
         users_keys (dict): public keys of users
         s_sk_dic (dict): s_sk of drop-out users (key: segment index, value: dict (key: quantization level, value: reconstructed_s_sk))
@@ -174,7 +176,8 @@ def unmasking(segment_info, G, segment_yu, surviving_users, users_keys, s_sk_dic
             mask = sum_pvu - sum_pu
 
             if len(segment_yu[l][q]) != 0:
-                segment_xu[l][q] = generatingOutput(segment_yu[l][q], mask)
-            #segment_xu[l][q] = sum(segment_yu[l][q]) + mask
+                #segment_xu[l][q] = sum(segment_yu[l][q]) + mask
+                sum_segment_yu = list(sum(x) for x in zip(*segment_yu[l][q])) # sum
+                segment_xu[l][q] = list(map(lambda x : x + mask, sum_segment_yu))  # remove mask
     
     return segment_xu

--- a/HeteroSAg.py
+++ b/HeteroSAg.py
@@ -110,11 +110,11 @@ def generateMaskedInputOfSegments(index, bu, xu, s_sk, B, G, group, perGroup, eu
                     p_uv_list.append(p_uv)
 
         print(f'puv list[{l}]: {p_uv_list}')
+
         # generate yu (masked xu) of segment l
         mask = pu + sum(p_uv_list)
-        # yu = add_to_weights(xu, mask)
-        # segment_yu[l] = fl.weights_to_dic_of_list(yu)
-        segment_yu[l][q] = xu + mask
+        masked_yu = add_to_weights(xu, mask)
+        segment_yu[l][q] = fl.weights_to_dic_of_list(masked_yu)
     
     return segment_yu
 
@@ -171,7 +171,9 @@ def unmasking(segment_info, G, segment_yu, surviving_users, users_keys, s_sk_dic
                         sum_pvu = sum_pvu + reconstructPvu(v, index, s_sk, users_keys[index]["s_pk"], R)
             print(f'sum pu / (recontructed) sum_pvu : {sum_pu} / {sum_pvu}')
             mask = sum_pvu - sum_pu
-            # segment_xu[l][q] = generatingOutput(segment_yu[l][q], mask)
-            segment_xu[l][q] = sum(segment_yu[l][q]) + mask
+
+            if len(segment_yu[l][q]) != 0:
+                segment_xu[l][q] = generatingOutput(segment_yu[l][q], mask)
+            #segment_xu[l][q] = sum(segment_yu[l][q]) + mask
     
     return segment_xu

--- a/HeteroSAg.py
+++ b/HeteroSAg.py
@@ -4,6 +4,7 @@ import SecureProtocol as sp
 from BasicSA import reconstruct, reconstructPu, reconstructPvu, generatingOutput
 from learning.utils import add_to_weights
 import learning.federated_main as fl
+import learning.models_helper as mhelper
 
 def quantization(x, Kg, r1, r2):
     # x = local model value of user i
@@ -114,7 +115,7 @@ def generateMaskedInputOfSegments(index, bu, xu, s_sk, B, G, group, perGroup, eu
         # generate yu (masked xu) of segment l
         mask = pu + sum(p_uv_list)
         masked_yu = add_to_weights(xu, mask)
-        segment_yu[l][q] = fl.weights_to_dic_of_list(masked_yu)
+        segment_yu[l][q] = mhelper.weights_to_dic_of_list(masked_yu)
     
     return segment_yu
 

--- a/client/BasicSAClient.py
+++ b/client/BasicSAClient.py
@@ -35,7 +35,7 @@ def sendRequestAndReceive(host, port, tag, request):
     response = ''
     try:
         response = json.loads(receivedStr)
-        print(f"[{tag}] Receive request")
+        print(f"[{tag}] Receive response")
         # print(f"[{tag}] receive response {response}")
         return response
     except json.decoder.JSONDecodeError:
@@ -169,8 +169,7 @@ class BasicSAClient:
             self.others_euv, 
             c_pk_dic, 
             U2, 
-            self.U3,
-            self.commonValues["R"])
+            self.U3)
         # requests example: {"idx": 0, "ssk_shares": {2: s20_sk, 3: s30_sk, ...}, "bu_shares": {1: b10, 4: b40, ...}]}
         request = {"idx": self.u, "ssk_shares": str(s_sk_shares_dic), "bu_shares": str(bu_shares_dic)}
 

--- a/client/HeteroSAClient.py
+++ b/client/HeteroSAClient.py
@@ -8,6 +8,7 @@ from dto.HeteroSetupDto import HeteroSetupDto
 import BasicSA as sa
 from HeteroSAg import generateMaskedInputOfSegments
 import learning.federated_main as fl
+from ast import literal_eval
 
 SIZE = 2048
 ENCODING = 'utf-8'
@@ -30,6 +31,7 @@ class HeteroSAClient:
     others_euv = {}
 
     weight = 0 # temp
+    model = {}
 
     def setUp(self):
         tag = BasicSARound.SetUp.name
@@ -37,7 +39,7 @@ class HeteroSAClient:
         # response: HeteroSetupDto
         response = sendRequestAndReceive(self.HOST, self.PORT, tag, {})
         setupDto = json.loads(json.dumps(response), object_hook=lambda d: HeteroSetupDto(**d)) #
-        print(setupDto)
+        #print(setupDto)
         
         self.n = setupDto.n
         self.t = setupDto.t
@@ -48,6 +50,15 @@ class HeteroSAClient:
         self.index = setupDto.index
         self.B = setupDto.B
         self.G = self.perGroup = setupDto.G # (For now,) G == groups num == users num of one group
+
+        self.data = setupDto.data
+        global_weights = fl.dic_of_list_to_weights(literal_eval(setupDto.weights))
+
+        if self.model == {}:
+            self.model = fl.setup()
+        fl.update_model(self.model, global_weights)
+        local_model, local_weight, local_loss = fl.local_update(self.model, self.data, 0) # epoch 0 (temp)
+        self.weight = local_weight
     
     def advertiseKeys(self):
         tag = BasicSARound.AdvertiseKeys.name
@@ -121,7 +132,7 @@ class HeteroSAClient:
                 self.p,
                 self.R
         )
-        print(f'segment_yu: {segment_yu}')
+        
         request = {"group": self.group, "index": self.index, "segment_yu": segment_yu}  # request example: {"group": 0, "index":0, "segment_yu": {0: y0}, {1: y1}}
 
         # receive sending_yu_list from server

--- a/client/HeteroSAClient.py
+++ b/client/HeteroSAClient.py
@@ -54,6 +54,7 @@ class HeteroSAClient:
 
         self.data = setupDto.data
         global_weights = mhelper.dic_of_list_to_weights(literal_eval(setupDto.weights))
+        self.weights_interval = setupDto.weights_interval
 
         if self.model == {}:
             self.model = fl.setup()
@@ -128,6 +129,7 @@ class HeteroSAClient:
                 self.G,
                 self.group,
                 self.perGroup,
+                self.weights_interval,
                 self.euv_list, 
                 s_pk_dic,
                 self.p,

--- a/client/HeteroSAClient.py
+++ b/client/HeteroSAClient.py
@@ -160,8 +160,7 @@ class HeteroSAClient:
             self.others_euv, 
             c_pk_dic, 
             U2, 
-            self.U3,
-            self.R)
+            self.U3)
         # requests example: {"idx": 0, "ssk_shares": {2: s20_sk, 3: s30_sk, ...}, "bu_shares": {1: b10, 4: b40, ...}]}
         request = {"index": self.index, "ssk_shares": str(s_sk_shares_dic), "bu_shares": str(bu_shares_dic)}
         print(request)

--- a/client/HeteroSAClient.py
+++ b/client/HeteroSAClient.py
@@ -8,6 +8,7 @@ from dto.HeteroSetupDto import HeteroSetupDto
 import BasicSA as sa
 from HeteroSAg import generateMaskedInputOfSegments
 import learning.federated_main as fl
+import learning.models_helper as mhelper
 from ast import literal_eval
 
 SIZE = 2048
@@ -52,7 +53,7 @@ class HeteroSAClient:
         self.G = self.perGroup = setupDto.G # (For now,) G == groups num == users num of one group
 
         self.data = setupDto.data
-        global_weights = fl.dic_of_list_to_weights(literal_eval(setupDto.weights))
+        global_weights = mhelper.dic_of_list_to_weights(literal_eval(setupDto.weights))
 
         if self.model == {}:
             self.model = fl.setup()

--- a/dto/HeteroSetupDto.py
+++ b/dto/HeteroSetupDto.py
@@ -10,8 +10,8 @@ class HeteroSetupDto(NamedTuple):
     index: int
     B: list
     G: int
-    # data: dict
-    # weights: dict
+    data: dict
+    weights: dict
 
 class HeteroKeysRequestDto(NamedTuple):
     group: int

--- a/dto/HeteroSetupDto.py
+++ b/dto/HeteroSetupDto.py
@@ -12,6 +12,7 @@ class HeteroSetupDto(NamedTuple):
     G: int
     data: dict
     weights: dict
+    weights_interval: list
 
 class HeteroKeysRequestDto(NamedTuple):
     group: int

--- a/learning/models_helper.py
+++ b/learning/models_helper.py
@@ -1,5 +1,6 @@
 import torch
 from iteration_utilities import deepflatten
+from .federated_main import args
 
 def get_model_weights(model):
     return model.state_dict()
@@ -13,7 +14,6 @@ def weights_to_dic_of_list(weights):
 # list to tensor, dic
 # returns new weights of model
 def dic_of_list_to_weights(dic_weights):
-    global args
     params = {}
     for param_tensor, value in dic_weights.items():
         if args.gpu: # cuda
@@ -88,3 +88,15 @@ def restore_weights_list(weights_info, flatten_weights):
         new_weights[layer] = layer_list
         prev = next
     return new_weights
+
+def get_weights_size(weights):
+    """ get size of tensor weights
+    Args:
+        weights (dict): model weights (model.state_dict())
+    Returns:
+        int: size of weights
+    """
+    weights_size = 0
+    for layer, item in weights.items():
+        weights_size = weights_size + item.shape.numel()
+    return weights_size

--- a/server/BasicSAServerV2.py
+++ b/server/BasicSAServerV2.py
@@ -73,7 +73,8 @@ class BasicSAServerV2:
 
                         print(f'[{round}] Client: {clientTag}/{addr}')
 
-                        self.userNum[i] = self.userNum[i] + 1
+                        if round == clientTag:
+                            self.userNum[i] = self.userNum[i] + 1
                     except socket.timeout:
                         pass
                     except:

--- a/server/HeteroSAServer.py
+++ b/server/HeteroSAServer.py
@@ -9,6 +9,7 @@ import HeteroSAg as hetero
 from dto.HeteroSetupDto import HeteroSetupDto, HeteroKeysRequestDto
 from CommonValue import BasicSARound
 import learning.federated_main as fl
+import learning.models_helper as mhelper
 import SecureProtocol as sp
 
 class HeteroSAServer(BasicSAServerV2):
@@ -42,7 +43,7 @@ class HeteroSAServer(BasicSAServerV2):
         # model
         if self.model == {}:
             self.model = fl.setup()
-        model_weights_list = fl.weights_to_dic_of_list(self.model.state_dict())
+        model_weights_list = mhelper.weights_to_dic_of_list(self.model.state_dict())
         user_groups = fl.get_user_dataset(self.usersNow)
 
         for i in range(self.G):
@@ -112,7 +113,7 @@ class HeteroSAServer(BasicSAServerV2):
             self.surviving_users.append(index)
             for i, segment in requestData["segment_yu"].items():
                 for q, yu in segment.items():
-                    yu_ = fl.dic_of_list_to_weights(yu)
+                    yu_ = mhelper.dic_of_list_to_weights(yu)
                     self.segment_yu[int(i)][int(q)].append(yu_)
 
         self.broadcast(requests, {"users": self.surviving_users})


### PR DESCRIPTION
## 개요
- HeteroSAg 프로토콜에 local learning 을 수행하는 부분 추가 및 기존의 오류 수정

## 작업사항
- HeteroSAg:
  - client 에서 local learning 을 수행하고 server 에서 받아서 unmasking 하는 것까지 구현
  - 기존에는 모든 segment 가 전체 weights 를 가지고 masking 을 했는데, **HeteroSAg 프로토콜에 따라 weights 를 segment 별로 분리하여 encode/decode 하도록 전반적으로 수정했습니다.**
  - 즉, 현재 저희 model 은 전체 weights 크기 (= weights 를 1차원으로 핀 상태에서의 모든 element 개수) 가 `21,840` 인데, 이때 segment 개수가 2 라면 segment 0 에서는 `0~10919`, segment 1 에서는 `10920~21839` 의 부분 weights 를 가지고 encode/decode 합니다.
  - 바뀐 구조에서 unmasking 이 segment 별로 잘 되는지는, 임의로 client 의 weights 를 서버에서 받아서 unmasking 후 값이 같은지 확인하는 과정을 통해 검증했습니다.
- BasicSA: ServerV2 에서의 오류를 수정 및 사용하지 않는 parameter 제거
- models-helper: `args` 에 대한 것 추가, `get_weights_size()`(: 전체 weights 크기 반환)  추가

## 확인할 사항
- 
