### PR TITLE
Hetero: coordinate-wise median, concatenate weights

### DIFF
--- a/HeteroSAg.py
+++ b/HeteroSAg.py
@@ -55,7 +55,6 @@ def getSegmentInfoFromB(B, G, perGroup):
         for i, value in enumerate(segment): # for each group            
             for idx in range(perGroup): # for each user
                 segment_info[l][value].append(i * perGroup + idx)
-    print(f'segment: {segment_info}')
     return segment_info
 
 def generateMaskedInputOfSegments(index, bu, xu, s_sk, B, G, group, perGroup, weights_interval, euv_list, s_pk_dic, p, R):
@@ -159,9 +158,12 @@ def unmasking(segment_info, G, segment_yu, surviving_users, users_keys, s_sk_dic
         dict: xu of segments (key: segment index, value: dict (key: quantization level, value: encoded xu))
     """
 
-    segment_xu = {i: {j: [] for j in range(G)} for i in range(G)} # i: segment level, j: quantization level
+    # segment_xu = {i: {j: [] for j in range(G)} for i in range(G)} # i: segment level, j: quantization level
+    segment_xu = {i: [] for i in range(G)} # i: segment level
     for l, value in segment_info.items(): 
         for q, index_list in value.items(): # q: quantization level
+            if len(segment_yu[l][q]) == 0: continue
+            
             # reconstruct per segment with same quantizer
             sum_pu = 0
             sum_pvu = 0
@@ -175,9 +177,9 @@ def unmasking(segment_info, G, segment_yu, surviving_users, users_keys, s_sk_dic
             print(f'sum pu / (recontructed) sum_pvu : {sum_pu} / {sum_pvu}')
             mask = sum_pvu - sum_pu
 
-            if len(segment_yu[l][q]) != 0:
-                #segment_xu[l][q] = sum(segment_yu[l][q]) + mask
-                sum_segment_yu = list(sum(x) for x in zip(*segment_yu[l][q])) # sum
-                segment_xu[l][q] = list(map(lambda x : x + mask, sum_segment_yu))  # remove mask
-    
+            #segment_xu[l][q] = sum(segment_yu[l][q]) + mask
+            sum_segment_yu = list(sum(x) for x in zip(*segment_yu[l][q])) # sum
+            # segment_xu[l][q] = list(map(lambda x : x + mask, sum_segment_yu))  # remove mask
+            segment_xu[l].append(list(map(lambda x : x + mask, sum_segment_yu))) # remove mask
+
     return segment_xu

--- a/client/HeteroSAClient.py
+++ b/client/HeteroSAClient.py
@@ -174,8 +174,9 @@ class HeteroSAClient:
 
 if __name__ == "__main__":
     client = HeteroSAClient()
-    client.setUp()
-    client.advertiseKeys()
-    client.shareKeys()
-    client.maskedInputCollection()
-    client.unmasking()
+    for i in range(5): # round
+        client.setUp()
+        client.advertiseKeys()
+        client.shareKeys()
+        client.maskedInputCollection()
+        client.unmasking()

--- a/learning/models_helper.py
+++ b/learning/models_helper.py
@@ -2,6 +2,17 @@ import torch
 from iteration_utilities import deepflatten
 from .federated_main import args
 
+default_weights_info = {
+    'conv1.weight': torch.Size([10, 1, 5, 5]),
+    'conv1.bias': torch.Size([10]),
+    'conv2.weight': torch.Size([20, 10, 5, 5]),
+    'conv2.bias': torch.Size([20]),
+    'fc1.weight': torch.Size([50, 320]),
+    'fc1.bias': torch.Size([50]),
+    'fc2.weight': torch.Size([10, 50]),
+    'fc2.bias': torch.Size([10])
+}
+
 def get_model_weights(model):
     return model.state_dict()
 

--- a/server/BasicSAServerV2.py
+++ b/server/BasicSAServerV2.py
@@ -31,12 +31,17 @@ class BasicSAServerV2:
     def __init__(self, n, k):
         self.n = n
         self.k = k # Repeat the entire process k times
+        self.serverSocket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.serverSocket.bind((self.host, self.port))
+        self.serverSocket.settimeout(self.timeout)
+        self.serverSocket.listen()
 
     def start(self):
-        serverSocket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        serverSocket.bind((self.host, self.port))
-        serverSocket.settimeout(self.timeout)
-        serverSocket.listen()
+        # init
+        self.users_keys = {}
+        self.yu_list = []
+
+        # start!
         print(f'[{self.__class__.__name__}] Server started')
             
         for j in range(self.k): # for k times
@@ -51,7 +56,7 @@ class BasicSAServerV2:
                 while (self.endTime - self.startTime) < self.interval:
                     currentClient = socket
                     try:
-                        clientSocket, addr = serverSocket.accept()
+                        clientSocket, addr = self.serverSocket.accept()
                         currentClient = clientSocket
 
                         # receive client data
@@ -95,7 +100,7 @@ class BasicSAServerV2:
                 self.saRound(round, self.requests[round])
         
         # End
-        serverSocket.close()
+        # serverSocket.close()
         print(f'[{self.__class__.__name__}] Server finished')
 
     # broadcast to all client (same response)
@@ -254,6 +259,9 @@ class BasicSAServerV2:
         # End
         self.broadcast(requests, "[Server] End protocol")
         fl.test_model(self.model)
+    
+    def close(self):
+        self.serverSocket.close()
 
 if __name__ == "__main__":
     server = BasicSAServerV2(n=3, k=5)

--- a/server/HeteroSAServer.py
+++ b/server/HeteroSAServer.py
@@ -30,6 +30,11 @@ class HeteroSAServer(BasicSAServerV2):
 
     # broadcast common value
     def setUp(self, requests):
+        # init
+        self.users_keys = {}
+        self.segment_yu = {}
+        self.surviving_users = []
+
         self.usersNow = len(requests)
         self.t = int(self.usersNow / 2) # threshold
 
@@ -189,4 +194,5 @@ class HeteroSAServer(BasicSAServerV2):
 
 if __name__ == "__main__":
     server = HeteroSAServer(n=4, k=1)
-    server.start()
+    for i in range(5): # round
+        server.start()

--- a/server/HeteroSAServer.py
+++ b/server/HeteroSAServer.py
@@ -1,4 +1,5 @@
 import os, sys, json
+import statistics
 from ast import literal_eval
 
 sys.path.append(os.path.dirname(os.path.abspath(os.path.dirname(__file__))))
@@ -172,16 +173,20 @@ class HeteroSAServer(BasicSAServerV2):
 
         # TODO dequantization encoded xu
 
-        # coordinate median
-
-        # concatenate
+        # coordinate-wise median and concatenate segment-level weights
+        concatenated = []
+        for l in range(len(segment_xu)):
+            median_xl = list(statistics.median(x) for x in zip(*segment_xu[l])) # sum
+            concatenated = concatenated + median_xl
+        new_weights = mhelper.restore_weights_tensor(mhelper.default_weights_info, concatenated)
 
         # update global model
+        fl.update_model(self.model, new_weights)
 
         # End
         self.broadcast(requests, "[Server] End protocol")
+        fl.test_model(self.model)
 
 if __name__ == "__main__":
     server = HeteroSAServer(n=4, k=1)
     server.start()
-    


### PR DESCRIPTION
## 개요
- HeteroSAg 프로토콜에서 마지막 stage 추가 구현

## 작업사항
- HeteroSAg 프로토콜에서 
  - 각 segment 별로 `coordinate-wise median` 수행,
  -  weight 들을 concatenate 하고 
  - global model 에 update 하는 것 구현
  - (quantization 은 되돌리는 것 때문에 아직 반영하지 않았습니다.)
- 여러 round 로 동작하도록 수정
- `models_helper` 에 현재 저희의 learning weights 의 구조를 `default_weights_info` 로 정의해두었습니다.
따라서, 필요에 따라 다음과 같은 형태로 사용할 수 있습니다. 
https://github.com/Lab-SA/SA/blob/5f10f83c6656376ddce2be979767c8b0b8a9f6f3/server/HeteroSAServer.py#L181

## 확인할 사항
1 server, 4 clients 로 테스트한 결과 (서버의 로그): [5round-working.txt](https://github.com/Lab-SA/SA/files/8675090/5round-working.txt)
- 처음의 두 라운드에서는 global weight 의 정확도가 증가하였으나 그 후로 감소함 
(여러 번 해봤는데, 모두 이와 같은 패턴으로 동작. 8% 대로 정확도가 떨어지기도 했습니다.)
- 이는 BasicSA 에서의 문제와 유사하다고 생각해 같이 추후 살펴보겠습니다.

