### PR TITLE
Hetero: add dequantization

### DIFF
--- a/HeteroSAg.py
+++ b/HeteroSAg.py
@@ -6,12 +6,17 @@ from learning.utils import add_to_weights
 import learning.federated_main as fl
 import learning.models_helper as mhelper
 
-def quantization(x, Kg, r1, r2):
+default_r1 = -1
+default_r2 = 0
+default_quantization_levels = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20]
+
+def quantization(x, _Kg, r1, r2):
     # x = local model value of user i
     # Kg = number of quantization levels
     # [r1, r2] = quantization range
 
     # delK = quantization interval
+    Kg = default_quantization_levels[_Kg]
     delK = (r2 - r1) / (Kg - 1)
 
     # T = discrete value from quantization range point list
@@ -26,6 +31,51 @@ def quantization(x, Kg, r1, r2):
         return Kg-1 # r2 choose Kg-1 with 100% probability
     
     return -1 # fail (only when x < r1 or x > r2)
+
+def quantization_weights(weights, _Kg, r1, r2):
+    # x = local weigths in 1-dim
+    # Kg = number of quantization levels
+    # [r1, r2] = quantization range
+
+    # delK = quantization interval
+    Kg = default_quantization_levels[_Kg]
+    delK = (r2 - r1) / (Kg - 1)
+
+    # T = discrete value from quantization range point list
+    T = [r1 + l * delK for l in range(0, Kg)]
+
+    quantized_weights = []
+    for x in weights:
+        if x < r1: x = r1
+        elif x > r2: x = r2
+        quantized_x = 0
+
+        for l in range(0, len(T)-1):
+            if T[l] <= x < T[l + 1]:
+                p = (x - T[l]) / (T[l + 1] - T[l])
+                prob_list = [p, 1-p]
+                quantized_x = random.choices([l+1, l], prob_list, k=1)[0]
+        if T[Kg-1] == x:
+            quantized_x = Kg-1 # r2 choose Kg-1 with 100% probability
+        quantized_weights.append(quantized_x)
+    
+    return quantized_weights
+
+def dequantization_weights(weights, _Kg, r1, r2, u):
+    # x = local weigths in 1-dim
+    # Kg = number of quantization levels
+    # [r1, r2] = quantization range
+    # u = number of surviving users of same segment
+
+    # delK = quantization interval
+    Kg = default_quantization_levels[_Kg]
+    delK = (r2 - r1) / (Kg - 1)
+
+    # T = discrete value from quantization range point list
+    real_numbers = [(u * r1) + (l * delK) for l in range(0, Kg)]
+    # real_numbers = [u * (r1 + (l * delK)) for l in range(0, Kg)]
+    # print(f'real_numbers: {real_numbers}')
+    return list(map(lambda x: real_numbers[int(x/u)], weights))
 
 def SS_Matrix(G):
     # G = the number of groups
@@ -58,7 +108,7 @@ def getSegmentInfoFromB(B, G, perGroup):
     return segment_info
 
 def generateMaskedInputOfSegments(index, bu, xu, s_sk, B, G, group, perGroup, weights_interval, euv_list, s_pk_dic, p, R):
-    """ generate masked input of segments
+    """ generate masked input of segments and do quantization
     Args:
         index (int): user's index
         bu (int): user's private mask
@@ -114,9 +164,12 @@ def generateMaskedInputOfSegments(index, bu, xu, s_sk, B, G, group, perGroup, we
 
         print(f'puv list[{l}]: {p_uv_list}')
 
+        # quantization weights
+        quantized_xu = quantization_weights(segment_xu[l], q, default_r1, default_r2)
+
         # generate yu (masked xu) of segment l
         mask = pu + sum(p_uv_list)
-        segment_yu[l][q] = list(map(lambda x : x + mask, segment_xu[l]))
+        segment_yu[l][q] = list(map(lambda x : x + mask, quantized_xu))
     
     return segment_yu
 
@@ -144,7 +197,7 @@ def reconstructSSKofSegments(B, G, perGroup, s_sk_shares_dic):
     return s_sk_dic
 
 def unmasking(segment_info, G, segment_yu, surviving_users, users_keys, s_sk_dic, bu_shares_dic, R):
-    """ generate masked input of segments
+    """ generate masked input of segments and do dequantization
     Args:
         segment_info (dict): segment info (key: segment index, value: dict (key: quantization level, value: index list))
         G (int): # of group
@@ -155,7 +208,7 @@ def unmasking(segment_info, G, segment_yu, surviving_users, users_keys, s_sk_dic
         bu_shares_dic (dict): shares for bu (key: index, value: list of shares)
         R (int): field
     Returns:
-        dict: xu of segments (key: segment index, value: dict (key: quantization level, value: encoded xu))
+        dict: xu(real-value) of segments (key: segment index, value: dict (key: quantization level, value: encoded xu))
     """
 
     # segment_xu = {i: {j: [] for j in range(G)} for i in range(G)} # i: segment level, j: quantization level
@@ -164,6 +217,8 @@ def unmasking(segment_info, G, segment_yu, surviving_users, users_keys, s_sk_dic
         for q, index_list in value.items(): # q: quantization level
             if len(segment_yu[l][q]) == 0: continue
             
+            surviving_num = 0 # number of surviving users of this segment
+
             # reconstruct per segment with same quantizer
             sum_pu = 0
             sum_pvu = 0
@@ -174,12 +229,19 @@ def unmasking(segment_info, G, segment_yu, surviving_users, users_keys, s_sk_dic
                     # recompute p_vu
                     for v, s_sk in s_sk_dic[l][q].items():
                         sum_pvu = sum_pvu + reconstructPvu(v, index, s_sk, users_keys[index]["s_pk"], R)
+                    
+                    surviving_num = surviving_num + 1
             print(f'sum pu / (recontructed) sum_pvu : {sum_pu} / {sum_pvu}')
             mask = sum_pvu - sum_pu
 
             #segment_xu[l][q] = sum(segment_yu[l][q]) + mask
             sum_segment_yu = list(sum(x) for x in zip(*segment_yu[l][q])) # sum
+
             # segment_xu[l][q] = list(map(lambda x : x + mask, sum_segment_yu))  # remove mask
-            segment_xu[l].append(list(map(lambda x : x + mask, sum_segment_yu))) # remove mask
+            raw_segment_xu = list(map(lambda x : x + mask, sum_segment_yu)) # remove mask
+            print(f'q level: {q} / surviving_num: {surviving_num} / min: {min(raw_segment_xu)} / max: {max(raw_segment_xu)}')
+
+            # dequantization: to real numbers
+            segment_xu[l].append(dequantization_weights(raw_segment_xu, q, default_r1, default_r2, surviving_num))
 
     return segment_xu

--- a/HeteroSAg.py
+++ b/HeteroSAg.py
@@ -65,17 +65,16 @@ def dequantization_weights(weights, _Kg, r1, r2, u):
     # x = local weigths in 1-dim
     # Kg = number of quantization levels
     # [r1, r2] = quantization range
-    # u = number of surviving users of same segment
+    # u = number of surviving users of same segment (= |U|)
 
     # delK = quantization interval
     Kg = default_quantization_levels[_Kg]
     delK = (r2 - r1) / (Kg - 1)
 
-    # T = discrete value from quantization range point list
-    real_numbers = [(u * r1) + (l * delK) for l in range(0, Kg)]
-    # real_numbers = [u * (r1 + (l * delK)) for l in range(0, Kg)]
+    # mapping to the corresponding values in discrete set of real numbers: |U|r1 ~ |U|r2
+    real_numbers = [(u * r1) + (l * delK) for l in range(0, u * (Kg-1) + 1)]
     # print(f'real_numbers: {real_numbers}')
-    return list(map(lambda x: real_numbers[int(x/u)], weights))
+    return list(map(lambda x: real_numbers[x], weights))
 
 def SS_Matrix(G):
     # G = the number of groups

--- a/client/HeteroSAClient.py
+++ b/client/HeteroSAClient.py
@@ -112,9 +112,6 @@ class HeteroSAClient:
     def maskedInputCollection(self):
         tag = BasicSARound.MaskedInputCollection.name
         
-        # quantization first
-        # TODO quantization weights (xu)
-
         s_pk_dic = {}
         for i, user_dic in self.others_keys.items():
             v = int(i)
@@ -171,7 +168,6 @@ class HeteroSAClient:
         # send u and dropped users' s_sk, survived users' bu in json format
         sendRequestAndReceive(self.HOST, self.PORT, tag, request)
     
-
 if __name__ == "__main__":
     client = HeteroSAClient()
     for i in range(5): # round

--- a/learning/models.py
+++ b/learning/models.py
@@ -22,3 +22,4 @@ class CNNMnist(nn.Module):
         x = F.dropout(x, training=self.training)
         x = self.fc2(x)
         return F.log_softmax(x, dim=1)
+        # return F.normalize(x, p=2, dim=0, eps=1e-5)

--- a/server/HeteroSAServer.py
+++ b/server/HeteroSAServer.py
@@ -162,7 +162,7 @@ class HeteroSAServer(BasicSAServerV2):
         
         # reconstruct s_sk of drop-out users
         s_sk_dic = hetero.reconstructSSKofSegments(self.B, self.G, self.perGroup, s_sk_shares_dic)
-        
+
         # unmasking
         segment_xu = hetero.unmasking(
             hetero.getSegmentInfoFromB(self.B, self.G, self.perGroup), 
@@ -175,8 +175,6 @@ class HeteroSAServer(BasicSAServerV2):
             self.R
         )
         #print(f'segment_xu: {segment_xu}')
-
-        # TODO dequantization encoded xu
 
         # coordinate-wise median and concatenate segment-level weights
         concatenated = []


### PR DESCRIPTION
## 개요
- HeteroSAg 에서 dequantization (quantized value to real number) 구현 및 반영

## 작업사항
- 1차원 리스트 형태로 이루어진 weights 를 quantization, dequantization 하는 부분을 구현했습니다.
- 현재 learning 값에 의해 `r1`=-1, `r2`=0 으로 설정했고,
- `default_quantization_levels` 는 제가 임의로 정의한 `Kg` 의 값들입니다.
- dequantization 은 논문에서 아래 이미지와 같이 명시되어 있었고,
  - ![image](https://user-images.githubusercontent.com/63097207/170916350-54daf1c0-dab8-48c2-a091-52d4073dee54.png)
  - |U| 를 곱하는 것은 |U| 만큼의 사용자 encoded weights 의 '합'을 구하였으므로 기존의 사용자 개개인의 weights 보다 |U| 만큼의 값이 나오기 때문입니다.
  - 즉, Kg=4, |U|=2 라면 사용자 개인 weights는 [0, 1, 2, 3] 의 범위로 quantization 되지만, 이 두 사용자의 weights 를 서버에서 합치면 [0, 1, 2, 3, 4, 5, 6] 의 범위를 갖게 됩니다(mask 가 제거된 값). 따라서 `|U|r1` 을 기저로 interval 을 반영하여 real numbers 의 리스트를 만들어서 mapping 하는 것입니다. 
  - Kg=4, |U|=2, r1=-1, r2=0 일 때 real numbers 의 리스트는 `[-2.0, -1.6666666666666667, -1.3333333333333335, -1.0, -0.6666666666666667, -0.3333333333333335, 0.0]` 가 되고, [0, 1, 2, 3, 4, 5, 6]이 이 값들에 mapping 됩니다.

## 확인할 사항
- HeteroSAg 에서의 quantization/dequantization 을 제가 제대로 이해/구현했는지 봐주시길 바랍니다.
- 또한,  5 round 를 돌렸을 때 global weighs 의 Test Accuracy 가 9.80% 로 매 round 마다 동일했고(...), Test Loss 만 조금씩 바뀌었습니다. 정확도가 오르지도, 내려가지도 않은 점이 이상해서 quantization/dequantization 과 그 외의 부분에서 잘못 구현된 부분이 있는지 살펴봐주시면 감사하겠습니다.
