### PR TITLE
fix(basic-sa): fix errors in averaging sum weights

### DIFF
--- a/learning/utils.py
+++ b/learning/utils.py
@@ -45,6 +45,14 @@ def get_users_data(args, num_users, train_dataset):
                 user_groups = mnist_noniid(train_dataset, num_users)
     return user_groups
 
+def average_weight(w, n):
+    """
+    Returns the average of the weight.
+    """
+    w_avg = copy.deepcopy(w)
+    for key in w_avg.keys():
+        w_avg[key] = torch.div(w_avg[key], n)
+    return w_avg
 
 def average_weights(w):
     """

--- a/server/BasicSAServerV2.py
+++ b/server/BasicSAServerV2.py
@@ -8,6 +8,7 @@ from CommonValue import BasicSARound
 from ast import literal_eval
 import learning.federated_main as fl
 import learning.models_helper as mhelper
+import learning.utils as utils
 import SecureProtocol as sp
 
 class BasicSAServerV2:
@@ -37,14 +38,14 @@ class BasicSAServerV2:
         self.serverSocket.listen()
 
     def start(self):
-        # init
-        self.users_keys = {}
-        self.yu_list = []
-
         # start!
         print(f'[{self.__class__.__name__}] Server started')
             
-        for j in range(self.k): # for k times
+        for j in range(self.k): # for k times        
+            # init
+            self.users_keys = {}
+            self.yu_list = []
+
             self.requests = {round.name: [] for round in BasicSARound}
             self.userNum = {i: 0 for i in range(len(BasicSARound))}
             self.userNum[-1] = self.n
@@ -254,7 +255,9 @@ class BasicSAServerV2:
         sum_xu = generatingOutput(self.yu_list, mask)
         
         # update global model
-        self.model = fl.update_globalmodel(self.model, sum_xu)
+        final_userNum = len(self.yu_list)
+        average_weight = utils.average_weight(sum_xu, final_userNum)
+        self.model.load_state_dict(average_weight)
         
         # End
         self.broadcast(requests, "[Server] End protocol")


### PR DESCRIPTION
## 개요
- BasicSA 에서의 weights 관련 오류 해결

## 작업사항
- `utils.average_weights()` 는 여러 weights 의 평균을 구하는 것인데,  현재 이미 합쳐진 weights 의 평균을 구해야 하는 것이므로 `n` 을 인자로 받아서 평균을 구하는 `utils.average_weight()` 함수를 만들어서 반영했습니다. ~~(weights 와 weight ...)~~
- 다음과 같이 2명의 client 로 4 global round 를 돌렸을 때 성공적으로 정확도가 증가함을 확인했습니다!
 ![image](https://user-images.githubusercontent.com/63097207/174008164-90ad83e9-7c4f-4064-a261-e007e518090f.png)

## 확인할 사항
- HeteroSA 에서의 오류는 quantization 과 관련된 문제로 추정되며 추후 작업 예정입니다.
