### PR TITLE
Fix/hetero: fix r2 value and average weights before madian

### DIFF
--- a/HeteroSAg.py
+++ b/HeteroSAg.py
@@ -214,7 +214,8 @@ def unmasking(segment_info, G, segment_yu, surviving_users, users_keys, s_sk_dic
     segment_xu = {i: [] for i in range(G)} # i: segment level
     for l, value in segment_info.items(): 
         for q, index_list in value.items(): # q: quantization level
-            if len(segment_yu[l][q]) == 0: continue
+            n = len(segment_yu[l][q])
+            if n == 0: continue
             
             surviving_num = 0 # number of surviving users of this segment
 
@@ -241,6 +242,7 @@ def unmasking(segment_info, G, segment_yu, surviving_users, users_keys, s_sk_dic
             # print(f'q level: {q} / surviving_num: {surviving_num} / min: {min(raw_segment_xu)} / max: {max(raw_segment_xu)}')
 
             # dequantization: to real numbers
-            segment_xu[l].append(dequantization_weights(raw_segment_xu, q, default_r1, default_r2, surviving_num))
+            dequantized = dequantization_weights(raw_segment_xu, q, default_r1, default_r2, surviving_num)
+            segment_xu[l].append(list(x/n for x in dequantized)) # y
 
     return segment_xu

--- a/HeteroSAg.py
+++ b/HeteroSAg.py
@@ -7,8 +7,8 @@ import learning.federated_main as fl
 import learning.models_helper as mhelper
 
 default_r1 = -1
-default_r2 = 0
-default_quantization_levels = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20]
+default_r2 = 1
+default_quantization_levels = [20, 30, 60, 80, 100]
 
 def quantization(x, _Kg, r1, r2):
     # x = local model value of user i
@@ -58,7 +58,7 @@ def quantization_weights(weights, _Kg, r1, r2):
         if T[Kg-1] == x:
             quantized_x = Kg-1 # r2 choose Kg-1 with 100% probability
         quantized_weights.append(quantized_x)
-    
+
     return quantized_weights
 
 def dequantization_weights(weights, _Kg, r1, r2, u):
@@ -238,7 +238,7 @@ def unmasking(segment_info, G, segment_yu, surviving_users, users_keys, s_sk_dic
 
             # segment_xu[l][q] = list(map(lambda x : x + mask, sum_segment_yu))  # remove mask
             raw_segment_xu = list(map(lambda x : x + mask, sum_segment_yu)) # remove mask
-            print(f'q level: {q} / surviving_num: {surviving_num} / min: {min(raw_segment_xu)} / max: {max(raw_segment_xu)}')
+            # print(f'q level: {q} / surviving_num: {surviving_num} / min: {min(raw_segment_xu)} / max: {max(raw_segment_xu)}')
 
             # dequantization: to real numbers
             segment_xu[l].append(dequantization_weights(raw_segment_xu, q, default_r1, default_r2, surviving_num))

--- a/server/HeteroSAServer.py
+++ b/server/HeteroSAServer.py
@@ -177,7 +177,7 @@ class HeteroSAServer(BasicSAServerV2):
         # coordinate-wise median and concatenate segment-level weights
         concatenated = []
         for l in range(len(segment_xu)):
-            median_xl = list(statistics.median(x) for x in zip(*segment_xu[l])) # sum
+            median_xl = list(statistics.median(x) for x in zip(*segment_xu[l])) # median
             concatenated = concatenated + median_xl
         new_weights = mhelper.restore_weights_tensor(mhelper.default_weights_info, concatenated)
 

--- a/server/HeteroSAServer.py
+++ b/server/HeteroSAServer.py
@@ -8,10 +8,8 @@ from BasicSAServerV2 import BasicSAServerV2
 from BasicSA import getCommonValues
 import HeteroSAg as hetero
 from dto.HeteroSetupDto import HeteroSetupDto, HeteroKeysRequestDto
-from CommonValue import BasicSARound
 import learning.federated_main as fl
 import learning.models_helper as mhelper
-import SecureProtocol as sp
 
 class HeteroSAServer(BasicSAServerV2):
     users_keys = {}
@@ -184,13 +182,12 @@ class HeteroSAServer(BasicSAServerV2):
         new_weights = mhelper.restore_weights_tensor(mhelper.default_weights_info, concatenated)
 
         # update global model
-        fl.update_model(self.model, new_weights)
+        self.model.load_state_dict(new_weights)
 
         # End
         self.broadcast(requests, "[Server] End protocol")
         fl.test_model(self.model)
 
 if __name__ == "__main__":
-    server = HeteroSAServer(n=4, k=1)
-    for i in range(5): # round
-        server.start()
+    server = HeteroSAServer(n=4, k=5)
+    server.start()


### PR DESCRIPTION
## 개요
- HeteroSAg 의 오류 해결

## 작업사항
- Model 에서 `log_softmax` 를 사용해서 `r1 = -1`, `r2 = 0` 으로 두고 작업했으나 실제 model 의 weight 값은 1까지임을 확인하고 `r2 = 1` 로 변경했습니다. (정확도 상승)
- 서버에서 합계 값을 다음과 같이 계산해야 합니다.
  - 같은 segment/quantization level 끼리 _`x`_ 값들을 더하고 -> mask 제거 -> deqantization 수행 -> **평균**
  - 같은 segment 끼리 위 결과값에 대해 median 수행
  - 위 결과값들, 즉 서로 다른 segment 의 weights 들을 concatenate
- 위 과정에서 평균값(_`y`_)을 구하는 과정이 없는 오류를 발견, 수정했습니다. (정확도 안정화)

## 정확도 테스트 결과
총 4가지 case 에 대해 정확도를 테스트했습니다.
공통: 4 users, 2 groups, 1 server

[case 1] quantization_levels = [2, 6]
5 round accuracy: `12.31 -> 5.64 -> 13.19 -> 8.43 -> 14.11 (%)`

[case 2] quantization_levels = [4, 10]
5 round accuracy: `13.25 -> 12.28 -> 12.47 -> 6.02 -> 9.93 (%)`

[case 3] quantization_levels = [20, 30]
5 round accuracy: `61.65 -> 80.09 -> 84.24 -> 86.02 -> 88.46 (%)`

[case 4] quantization_levels = [20, 30]
10 round accuracy: `35.57 -> 73.75 -> 84.59 -> 86.37 -> 88.23 -> 90.12 -> 89.47 -> 89.66 -> 90.42 -> 91.59 (%)`


## 확인할 사항
- 
