### PR TITLE
Feat/balanced SA networking

### DIFF
--- a/BalancedSA.py
+++ b/BalancedSA.py
@@ -60,7 +60,7 @@ def generateMasks(idx, n, ri, pub_keys, g, p, R):
             m = mask[k] = random.randrange(1, R) % p
             sum_mask = sum_mask + m
         
-        encrypted_mask[k] = encrypt(pub_keys[k], bytes(str(m), 'ascii'))
+        encrypted_mask[k] = encrypt(pub_keys[k], bytes(str(m), 'ascii')).hex()
         public_mask[k] = (g ** m) % p
     
     return mask, encrypted_mask, public_mask
@@ -87,9 +87,10 @@ def verifyMasks(idx, ri, n, encrypted_mask, public_mask, sk, g, p):
     # verify Mkj = g^mkj mod p
     mask = {}
     for k, mkj in encrypted_mask.items():
-        mask[k] = m = int(bytes.decode(decrypt(sk, mkj), 'ascii'))
-        if public_mask[k][idx] != (g ** m) % p:
+        mask[k] = m = int(bytes.decode(decrypt(sk, bytes.fromhex(mkj)), 'ascii'))
+        if public_mask[k][str(idx)] != (g ** m) % p:
             print('Mask is Invalid. 1')
+            return {}
             #raise Exception('Mask is Invalid. 1')
     
     Ri = (g ** ri) % p
@@ -101,6 +102,7 @@ def verifyMasks(idx, ri, n, encrypted_mask, public_mask, sk, g, p):
             mul_Mkn = (mul_Mkn * Mkn) % p
         if Ri != mul_Mkn:
             print('Mask is Invalid. 2')
+            return {}
             #raise Exception('Mask is Invalid. 2')
     
     return mask

--- a/BalancedSA.py
+++ b/BalancedSA.py
@@ -12,8 +12,8 @@ def generateECCKey():
     secp_k = generate_key()
     sk_bytes = secp_k.secret
     pk_bytes = secp_k.public_key.format(True)
-    # encrypt(pk_hex, plain)
-    # decrypt(sk_hex, cipher)
+    # encrypt(pk_bytes, plain)
+    # decrypt(sk_bytes, cipher)
     return sk_bytes, pk_bytes
 
 def generateRandomNonce(c, g, p, R):

--- a/BalancedSA.py
+++ b/BalancedSA.py
@@ -102,6 +102,7 @@ def verifyMasks(idx, ri, n, encrypted_mask, public_mask, sk, g, p):
             mul_Mkn = (mul_Mkn * Mkn) % p
         if Ri != mul_Mkn:
             print('Mask is Invalid. 2')
+            return mask # temp
             return {}
             #raise Exception('Mask is Invalid. 2')
     
@@ -126,7 +127,7 @@ def computeReconstructionValue(drop_out, my_masks, masks):
     Args:
         drop_out (list): index list of drop-out users
         my_masks (dict): random masks by this user (mjk)
-        mask (dict): random masks (mkj)
+        mask (dict): random masks by other users (mkj)
     Returns:
         int: reconstruction value RSj
     """

--- a/CommonValue.py
+++ b/CommonValue.py
@@ -14,3 +14,8 @@ class TurboRound(Enum):
     TurboFinal = 7012
     Final = 7020
 
+class BalancedSARound(Enum):
+    SetUp = 1
+    ShareMasks = 2
+    Aggregation = 3
+    RemoveMasks = 4

--- a/client/BalancedSAClient.py
+++ b/client/BalancedSAClient.py
@@ -93,6 +93,8 @@ class BalancedSAClient:
         response = sendRequestAndReceive(self.HOST, self.PORT, tag, request)
 
         self.dropout = response['dropout']
+        if len(self.dropout) > 0:
+            self.sendMasksOfDropout()
 
     def sendMasksOfDropout(self): # send the masks of drop-out users
         tag = BalancedSARound.RemoveMasks.name
@@ -108,4 +110,3 @@ if __name__ == "__main__":
     while not client.shareRandomMasks(): # repeat step 2 until all member share valid mask
         continue
     client.sendSecureWeight()
-    client.sendMasksOfDropout()

--- a/client/BalancedSAClient.py
+++ b/client/BalancedSAClient.py
@@ -73,8 +73,17 @@ class BalancedSAClient:
         self.my_mask, encrypted_mask, public_mask = BalancedSA.generateMasks(self.index, self.clusterN, self.ri, self.others_keys, self.g, self.p, self.R)
         request = {'cluster': self.cluster, 'index': self.index, 'emask': encrypted_mask, 'pmask': public_mask}
         response = sendRequestAndReceive(self.HOST, self.PORT, tag, request)
+        # print(self.my_mask, public_mask)
 
-        return True # TODO
+        emask = {int(key): value for key, value in response['emask'].items()}
+        pmask = {int(key): value for key, value in response['pmask'].items()}
+        # print(self.ri, self.Ri, pmask)
+        self.others_mask = BalancedSA.verifyMasks(self.index, self.ri, self.clusterN, emask, pmask, self.my_sk, self.g, self.p)
+        
+        if self.others_mask == {}:
+            return False # failed
+        else:
+            return True
 
     def sendSecureWeight(self): # send secure weight S
         tag = BalancedSARound.Aggregation.name

--- a/client/BalancedSAClient.py
+++ b/client/BalancedSAClient.py
@@ -88,14 +88,19 @@ class BalancedSAClient:
     def sendSecureWeight(self): # send secure weight S
         tag = BalancedSARound.Aggregation.name
 
-        request = {'cluster': self.cluster, 'index': self.index}
+        S = BalancedSA.generateSecureWeight(self.weight, self.ri, self.others_mask)
+        request = {'cluster': self.cluster, 'index': self.index, 'S': S}
         response = sendRequestAndReceive(self.HOST, self.PORT, tag, request)
+
+        self.dropout = response['dropout']
 
     def sendMasksOfDropout(self): # send the masks of drop-out users
         tag = BalancedSARound.RemoveMasks.name
 
-        request = {'cluster': self.cluster, 'index': self.index}
+        RS = BalancedSA.computeReconstructionValue(self.dropout, self.my_mask, self.others_mask)
+        request = {'cluster': self.cluster, 'index': self.index, 'RS': RS}
         response = sendRequestAndReceive(self.HOST, self.PORT, tag, request)
+        print(response)
 
 if __name__ == "__main__":
     client = BalancedSAClient()

--- a/client/BalancedSAClient.py
+++ b/client/BalancedSAClient.py
@@ -1,0 +1,78 @@
+import os, sys, json
+
+sys.path.append(os.path.dirname(os.path.abspath(os.path.dirname(__file__))))
+
+import BalancedSA
+from CommonValue import BalancedSARound
+from BasicSAClient import sendRequestAndReceive
+import learning.federated_main as fl
+import learning.models_helper as mhelper
+from dto.BalancedSetupDto import BalancedSetupDto
+from ast import literal_eval
+
+SIZE = 2048
+ENCODING = 'utf-8'
+
+class BalancedSAClient:
+    HOST = 'localhost'
+    PORT = 7000
+
+    n = g = p = R = 0 # common values
+    cluster = clusterN = 0
+    index = 0
+    ri = 0
+
+    my_sk = my_pk = 0
+    others_keys = {}  # other users' public key dic
+    weight = {}
+    model = {}
+
+    def setUp(self):
+        tag = BalancedSARound.SetUp.name
+
+        self.my_sk, self.my_pk = BalancedSA.generateECCKey()
+
+        # request with my public key (pk)
+        # response: BalancedSetupDto
+        response = sendRequestAndReceive(self.HOST, self.PORT, tag, {'pk': self.my_pk})
+        setupDto = json.loads(json.dumps(response), object_hook=lambda d: BalancedSetupDto(**d)) #
+        
+        self.n = setupDto.n
+        self.g = setupDto.g
+        self.p = setupDto.p
+        self.R = setupDto.R
+        # TODO self.ri = 
+        self.cluster = setupDto.cluster
+        self.clusterN = setupDto.clusterN
+        self.index = setupDto.index
+
+        self.data = setupDto.data
+        global_weights = mhelper.dic_of_list_to_weights(literal_eval(setupDto.weights))
+
+        self.weight = 1 # temp
+
+        #if self.model == {}:
+        #    self.model = fl.setup()
+        #fl.update_model(self.model, global_weights)
+        #local_model, local_weight, local_loss = fl.local_update(self.model, self.data, 0) # epoch 0 (temp)
+        #self.weight = local_weight
+    
+    def shareRandomMasks(self): # send random masks
+        tag = BalancedSARound.ShareMasks.name
+
+
+    def sendSecureWeight(self): # send secure weight S
+        tag = BalancedSARound.Aggregation.name
+
+
+    def sendMasksOfDropout(self): # send the masks of drop-out users
+        tag = BalancedSARound.RemoveMasks.name
+    
+
+if __name__ == "__main__":
+    client = BalancedSAClient()  # test
+    client.setUp()
+    while not client.shareRandomMasks(): # repeat step 2 until all member share valid mask
+        continue
+    client.sendSecureWeight()
+    client.sendMasksOfDropout()

--- a/client/BasicSAClient.py
+++ b/client/BasicSAClient.py
@@ -8,6 +8,18 @@ import learning.models_helper as mhelper
 SIZE = 2048
 ENCODING = 'utf-8'
 
+def sendRequest(host, port, tag, request):
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.connect((host, port))
+    print(f"[{tag}] Server connected!")
+
+    # add tag to request
+    request['request'] = tag
+
+    # send request
+    s.sendall(bytes(json.dumps(request) + "\r\n", ENCODING))
+    print(f"[{tag}] Send request (no response)")
+
 def sendRequestAndReceive(host, port, tag, request):
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     s.connect((host, port))

--- a/dto/BalancedSetupDto.py
+++ b/dto/BalancedSetupDto.py
@@ -1,0 +1,13 @@
+from typing import NamedTuple
+
+class BalancedSetupDto(NamedTuple):
+    n: int
+    g: int
+    p: int
+    R: int
+    encrypted_ri: int
+    cluster: int    # cluster index
+    clusterN: int   # number of nodes in cluster
+    index: int
+    data: dict
+    weights: dict

--- a/dto/BalancedSetupDto.py
+++ b/dto/BalancedSetupDto.py
@@ -6,8 +6,10 @@ class BalancedSetupDto(NamedTuple):
     p: int
     R: int
     encrypted_ri: int
+    Ri: int
     cluster: int    # cluster index
     clusterN: int   # number of nodes in cluster
+    cluster_keys: dict
     index: int
     data: dict
     weights: dict

--- a/server/BalancedSAServer.py
+++ b/server/BalancedSAServer.py
@@ -1,0 +1,177 @@
+import socket, json, time, sys, os
+
+from dto.BalancedSetupDto import BalancedSetupDto
+
+sys.path.append(os.path.dirname(os.path.abspath(os.path.dirname(__file__))))
+
+from BasicSA import getCommonValues
+from CommonValue import BalancedSARound
+from ast import literal_eval
+import learning.federated_main as fl
+import learning.models_helper as mhelper
+import learning.utils as utils
+
+class BalancedSAServer:
+    host = 'localhost'
+    port = 7000
+    SIZE = 2048
+    ENCODING = 'utf-8'
+    interval = 60 * 10 # server waits in one round # second
+    timeout = 3
+    totalRound = 4 # BalancedSA has 4 rounds
+
+    userNum = {}
+    requests = []
+
+    model = {}
+    users_keys = {}
+    R = 0
+
+    def __init__(self, n, k):
+        self.n = n
+        self.k = k # Repeat the entire process k times
+        self.serverSocket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.serverSocket.bind((self.host, self.port))
+        self.serverSocket.settimeout(self.timeout)
+
+    def start(self):
+        # start!
+        self.serverSocket.listen()
+        print(f'[{self.__class__.__name__}] Server started')
+            
+        for j in range(self.k): # for k times        
+            # init
+            self.users_keys = {}
+            self.yu_list = []
+
+            self.requests = {round.name: [] for round in BalancedSARound}
+            self.userNum = {i: 0 for i in range(len(BalancedSARound))}
+            self.userNum[-1] = self.n
+
+            # execute BasicSA round (total 5)
+            for i, r in enumerate(BalancedSARound):
+                round = r.name
+                self.startTime = self.endTime = time.time()
+                while (self.endTime - self.startTime) < self.interval:
+                    currentClient = socket
+                    try:
+                        clientSocket, addr = self.serverSocket.accept()
+                        currentClient = clientSocket
+
+                        # receive client data
+                        # client request must ends with "\r\n"
+                        request = ''
+                        while True:
+                            received = str(clientSocket.recv(self.SIZE), self.ENCODING)
+                            if received.endswith("\r\n"):
+                                received = received.replace("\r\n", "")
+                                request = request + received
+                                break
+                            request = request + received
+
+                        requestData = json.loads(request)
+                        # request must contain {request: tag}
+                        clientTag = requestData['request']
+                        requestData.pop('request')
+                        self.requests[clientTag].append((clientSocket, requestData))
+
+                        print(f'[{round}] Client: {clientTag}/{addr}')
+
+                        if round == clientTag:
+                            self.userNum[i] = self.userNum[i] + 1
+                    except socket.timeout:
+                        pass
+                    except:
+                        print(f'[{self.__class__.__name__}] Exception: invalid request or unknown server error')
+                        currentClient.sendall(bytes('Exception: invalid request or unknown server error\r\n', self.ENCODING))
+                        pass
+                    
+                    self.endTime = time.time()
+                    if self.userNum[i] >= self.userNum[i-1]:
+                        break
+
+                # check threshold
+                if self.t > self.userNum[i]:
+                    print(f'[{self.__class__.__name__}] Exception: insufficient {self.userNum[i]} users with {self.t} threshold')
+                    raise Exception(f"Need at least {self.t} users, but only {self.userNum[i]} user(s) responsed")
+            
+                # do
+                self.saRound(round, self.requests[round])
+        
+        # End
+        # serverSocket.close()
+        print(f'[{self.__class__.__name__}] Server finished')
+
+    # broadcast to all client (same response)
+    def broadcast(self, requests, response): # send response (broadcast)
+        response_json = json.dumps(response)
+        for client in requests:
+            clientSocket = client[0]
+            clientSocket.sendall(bytes(response_json + "\r\n", self.ENCODING))
+
+    def saRound(self, tag, requests):
+        if tag == BalancedSARound.SetUp.name:
+            self.setUp(requests)
+        elif tag == BalancedSARound.ShareMasks.name:
+            self.shareMasks(requests)
+        elif tag == BalancedSARound.Aggregation.name:
+            self.aggregationInCluster(requests)
+        elif tag == BalancedSARound.RemoveMasks.name:
+            self.finalAggregation(requests)
+
+
+    # broadcast common value
+    def setUp(self, requests):
+        usersNow = len(requests)
+        
+        commonValues = getCommonValues()
+        self.g = commonValues["g"]
+        self.p = commonValues["p"]
+        self.R = commonValues["R"]
+
+        if self.model == {}:
+            self.model = fl.setup()
+        model_weights_list = mhelper.weights_to_dic_of_list(self.model.state_dict())
+        user_groups = fl.get_user_dataset(self.n)
+
+        self.perGroup = 2 # temp
+        self.clusterNum = int(usersNow / self.perGroup) # temp
+        for i in range(self.clusterNum):
+            for j in range(self.perGroup):
+                idx = i*self.perGroup + j
+                response_ij = BalancedSetupDto(
+                    n = usersNow, 
+                    g = self.g, 
+                    p = self.p, 
+                    R = self.R, 
+                    encrypted_ri = 1, # TODO
+                    cluster = i,
+                    clusterN = self.perGroup,
+                    index = idx,
+                    data = [int(k) for k in user_groups[idx]],
+                    weights= str(model_weights_list),
+                )._asdict()
+                response_json = json.dumps(response_ij)
+                clientSocket = requests[idx][0]
+                clientSocket.sendall(bytes(response_json + "\r\n", self.ENCODING))
+    
+
+    def shareMasks(self, requests):
+        response = {}
+
+
+    def aggregationInCluster(self, requests):
+        response = {}
+    
+
+    def finalAggregation(self, requests):
+        response = {}
+    
+
+    def close(self):
+        self.serverSocket.close()
+
+
+if __name__ == "__main__":
+    server = BalancedSAServer(n=3, k=5)
+    server.start()

--- a/server/BasicSAServerV2.py
+++ b/server/BasicSAServerV2.py
@@ -1,4 +1,3 @@
-from http import client
 import socket, json, time, copy, sys, os
 
 sys.path.append(os.path.dirname(os.path.abspath(os.path.dirname(__file__))))
@@ -9,7 +8,6 @@ from ast import literal_eval
 import learning.federated_main as fl
 import learning.models_helper as mhelper
 import learning.utils as utils
-import SecureProtocol as sp
 
 class BasicSAServerV2:
     host = 'localhost'


### PR DESCRIPTION
## 개요
- BalancedSA 의 네트워킹 부분을 작업했습니다.

## 작업사항
- BalancedSA 는 다음과 같은 과정(stage)으로 이루어지며, 이를 구현했습니다.
  - step 1) random nonces(`ri`) 를 각 cluster 에 전송 - `BalancedSARound.SetUp`
  - step 2) 동일 cluster 내의 node(client)들은 `ri` 를 가지고 random masks(`m`)를 생성 및 전송 - `BalancedSARound.ShareMasks`
    각 node 들은 mask 를 검증 (`M` 으로), 검증에 실패하면 이 과정 반복
  - step 3) 각 node 는 받은 mask 들로 자신의 weight 에 대한 secure wieght `S` 를 계산, 서버에 전송 - `BalancedSARound.Aggregation`
  - step 4) 서버는 cluster 별로 intermediate sum `IS` 계산, drop out 사용자가 있다면 reconstruction value `RS` 요청 - `BalancedSARound.RemoveMasks`
    단, drop out 사용자가 없는 cluster 는 이 과정을 생략합니다.
  - 마지막으로, 모든 `RS` 를 받으면 서버는 최종 aggregated sum `S` 를 계산합니다.
- 검증에 실패하면 step 2 를 반복하는 것을 확인했고, learning 부분과 현재 프로토콜에 이슈가 있는 부분, clustring 부분을 제외한 부분들을 구현했습니다.
- 실제 네트워킹 부분에서는 `BalancedSA.computeIntermediateSum` 함수를 사용하지 않습니다. 이는 임시적으로 프로토콜을 검증하기 위해 남겨둔 것으로 생각해주세요.
- 기존 `sendRequestAndReceive`와 달리 response 를 기다리지 않는 `client/BasicSAClient.py/sendRequest` 함수를 만들어두었습니다.

## 확인할 사항
- 추가된 패키지, 리뷰가 필요한 부분 등
