### PR TITLE
Fix/basicSA: fix error in key exchange and refactor

### DIFF
--- a/BasicSA.py
+++ b/BasicSA.py
@@ -40,6 +40,7 @@ def generateSharesOfMask(t, u, s_sk, c_sk, users, R):
 
     for i, user_dic in users.items():
         v = int(i)
+        if u == v: continue
         c_pk = user_dic["c_pk"]
         s_uv = sp.agree(c_sk, c_pk, p)
         plainText = str([u, v, s_sk_shares_list[v], bu_shares_list[v]])

--- a/BasicSA.py
+++ b/BasicSA.py
@@ -29,19 +29,19 @@ def generateKeyPairs():
     return (c_pk, c_sk), (s_pk, s_sk)
 
 # Generate secret-shares of s_sk and bu and encrypt those data
-# users [dictionary]: all users of the current round
-def generateSharesOfMask(t, u, s_sk, c_sk, users, R):
+# c_pk_dic [dictionary]: all users' c_pk of the current round
+def generateSharesOfMask(t, u, s_sk, c_sk, c_pk_dic, R):
     global p
 
+    n = len(c_pk_dic)
     bu = random.randrange(1, R) # 1~R
-    s_sk_shares_list = sp.make_shares(s_sk, t, len(users))
-    bu_shares_list = sp.make_shares(bu, t, len(users))
+    s_sk_shares_list = sp.make_shares(s_sk, t, n)
+    bu_shares_list = sp.make_shares(bu, t, n)
     euv_list = []
 
-    for i, user_dic in users.items():
+    for i, c_pk in c_pk_dic.items():
         v = int(i)
         if u == v: continue
-        c_pk = user_dic["c_pk"]
         s_uv = sp.agree(c_sk, c_pk, p)
         plainText = str([u, v, s_sk_shares_list[v], bu_shares_list[v]])
         euv = sp.encrypt(s_uv, plainText)

--- a/SecureProtocol.py
+++ b/SecureProtocol.py
@@ -28,14 +28,14 @@ def gcd(a, b):
 # key generate
 def generateKeyPair(g, p):
     pri_key = random.randrange(50000, 90000) #temp
-    pub_key = g ** pri_key % p
+    pub_key = (g ** pri_key) % p
     return pub_key, pri_key
 
 # key agreement with hash function (md5)
 # return 128bit key
 def agree(sk, pk, p):
     # key = H((g^a)^b)
-    key = pk ** sk % p
+    key = (pk ** sk) % p
     # key agreement composed with a hash function md5: generate 128-bit key
     return hashlib.md5(bytes(key)).hexdigest()
 

--- a/client/BasicSAClient.py
+++ b/client/BasicSAClient.py
@@ -96,7 +96,7 @@ class BasicSAClient:
         self.my_keys["c_sk"] = c_sk 
         self.my_keys["s_pk"] = s_pk
         self.my_keys["s_sk"] = s_sk
-        request = {"c_pk": c_pk, "s_pk": s_pk}
+        request = {"index": self.u, "c_pk": c_pk, "s_pk": s_pk}
 
         # send {"c_pk": c_pk, "s_pk": s_pk} to server in json format
         # receive other users' public keys from server in json format

--- a/client/HeteroSAClient.py
+++ b/client/HeteroSAClient.py
@@ -19,7 +19,6 @@ class HeteroSAClient:
     PORT = 7000
     xu = 0  # temp. local model of this client
 
-    u = 0  # u = user index
     n = t = g = p = R = 0 # common values
     group = 0
     index = 0
@@ -92,16 +91,15 @@ class HeteroSAClient:
 
         # t = threshold, u = user index
         # request = [[u, v1, euv], [u, v2, euv], ...]
-        euv_list, bu = sa.generateSharesOfMask(
+        self.euv_list, self.bu = sa.generateSharesOfMask(
             self.t,
             self.index,
             self.my_keys["s_sk"], 
             self.my_keys["c_sk"], 
             self.c_pk_dic,
-            self.R)
-        self.euv_list = euv_list
-        self.bu = bu
-        request = {self.index: euv_list}
+            self.R
+        )
+        request = {"index": self.index, "euv": self.euv_list}
 
         # receive euv_list from server in json format
         response = sendRequestAndReceive(self.HOST, self.PORT, tag, request)
@@ -154,7 +152,8 @@ class HeteroSAClient:
             self.others_euv, 
             self.c_pk_dic,
             U2, 
-            self.U3)
+            self.U3
+        )
         # requests example: {"idx": 0, "ssk_shares": {2: s20_sk, 3: s30_sk, ...}, "bu_shares": {1: b10, 4: b40, ...}]}
         request = {"index": self.index, "ssk_shares": str(s_sk_shares_dic), "bu_shares": str(bu_shares_dic)}
         print(request)

--- a/client/HeteroSAClient.py
+++ b/client/HeteroSAClient.py
@@ -26,9 +26,10 @@ class HeteroSAClient:
     B = []
     G = perGroup = 0
     
-    my_keys = {}  # c_pk, c_sk, s_pk, s_sk of this client
-    others_keys = {}  # other users' public key dic\
-    euv_list = []  # euv of this client
+    my_keys = {}    # c_pk, c_sk, s_pk, s_sk of this client
+    s_pk_dic = {}   # other users' s_pk(public key) dic
+    c_pk_dic = {}   # other users' c_pk(public key) dic
+    euv_list = []   # euv of this client
     others_euv = {}
 
     weight = 0 # temp
@@ -78,7 +79,12 @@ class HeteroSAClient:
 
         # store response on client
         # example: {"0": {"c_pk": "2123", "s_pk": "3333"}, "1": {"c_pk": "1111", "s_pk": "2222"}}
-        self.others_keys = response
+        self.s_pk_dic = {}
+        self.c_pk_dic = {}
+        for i, user_dic in response.items():
+            v = int(i)
+            self.s_pk_dic[v] = user_dic["s_pk"]
+            self.c_pk_dic[v] = user_dic["c_pk"]
 
 
     def shareKeys(self):
@@ -91,7 +97,7 @@ class HeteroSAClient:
             self.index,
             self.my_keys["s_sk"], 
             self.my_keys["c_sk"], 
-            self.others_keys,
+            self.c_pk_dic,
             self.R)
         self.euv_list = euv_list
         self.bu = bu
@@ -112,11 +118,6 @@ class HeteroSAClient:
     def maskedInputCollection(self):
         tag = BasicSARound.MaskedInputCollection.name
         
-        s_pk_dic = {}
-        for i, user_dic in self.others_keys.items():
-            v = int(i)
-            s_pk_dic[v] = user_dic.get("s_pk")
-        
         segment_yu = generateMaskedInputOfSegments(
                 self.index,
                 self.bu, 
@@ -128,7 +129,7 @@ class HeteroSAClient:
                 self.perGroup,
                 self.weights_interval,
                 self.euv_list, 
-                s_pk_dic,
+                self.s_pk_dic,
                 self.p,
                 self.R
         )
@@ -143,13 +144,6 @@ class HeteroSAClient:
 
     def unmasking(self): # same as unmasking of BasicSACLient
         tag = BasicSARound.Unmasking.name
-        s_sk_shares_dic = {}
-        bu_shares_dic = {}
-
-        c_pk_dic = {}
-        for i, user_dic in self.others_keys.items():
-            v = int(i)
-            c_pk_dic[v] = user_dic.get("c_pk")
 
         # U2 = survived users in round1(shareKeys) = users_previous
         U2 = list(self.others_euv.keys())
@@ -158,7 +152,7 @@ class HeteroSAClient:
             self.index,
             self.my_keys["c_sk"], 
             self.others_euv, 
-            c_pk_dic, 
+            self.c_pk_dic,
             U2, 
             self.U3)
         # requests example: {"idx": 0, "ssk_shares": {2: s20_sk, 3: s30_sk, ...}, "bu_shares": {1: b10, 4: b40, ...}]}

--- a/server/BasicSAServerV2.py
+++ b/server/BasicSAServerV2.py
@@ -161,11 +161,10 @@ class BasicSAServerV2:
         
         # response example: {0: {"index":0, "c_pk":"VALUE", "s_pk": "VALUE"}, 1: {"index":0, "c_pk":"VALUE", "s_pk": "VALUE"} }
         response = {}
-        for v, request in enumerate(requests):
-            requestData = request[1]  # (socket, data)
-            self.users_keys[v] = requestData  # store on server
-            requestData['index'] = v # add index
-            response[v] = requestData
+        for _, requestData in requests: # (socket, data)
+            index = requestData['index']
+            self.users_keys[index] = requestData  # store on server
+            response[index] = requestData
         self.broadcast(requests, response)
 
     def shareKeys(self, requests):

--- a/server/BasicSAServerV2.py
+++ b/server/BasicSAServerV2.py
@@ -114,6 +114,7 @@ class BasicSAServerV2:
         # 'response' must be: { index: [response], ... }
         # 'requestData' must be: { index: [...data], ... }
         for (clientSocket, requestData) in requests:
+
             idx = 0
             for data in requestData.keys():
                 idx = data
@@ -170,23 +171,20 @@ class BasicSAServerV2:
     def shareKeys(self, requests):
         # (one) request example: {0: [(0, 0, e00), (0, 1, e01) ... ]}
         # requests example: [{0: [(0, 0, e00), ... ]}, {1: [(1, 0, e10), ... ]}, ... ]
-
         # response example: { 0: [e00, e10, e20, ...], 1: [e01, e11, e21, ... ] ... }
-        response = {}
-        requests_euv = []
-        for request in requests:
-            requestData = request[1]  # (socket, data)
-            for idx, data in requestData.items(): #only one
-                response[idx] = {}  # make dic
-                requests_euv.append(data)
-        for request in requests_euv:
-            for (u, v, euv) in request:
-                try:
-                    response[str(v)][u] = euv
-                except KeyError:  # drop-out
-                    print("KeyError")
-                    pass
-        self.foreach(requests, response)
+
+        euvs = {}
+        for _, requestData in requests: # (socket, data)
+            for u, v, euv in requestData['euv']:
+                if euvs.get(v) is None:
+                    euvs[v] = {}
+                euvs[v][u] = euv
+
+        # send response
+        for clientSocket, requestData in requests:
+            index = requestData['index']
+            response_json = json.dumps(euvs[index])
+            clientSocket.sendall(bytes(response_json + "\r\n", self.ENCODING))
         
     def maskedInputCollection(self, requests):
         # if u3 dropped
@@ -194,24 +192,22 @@ class BasicSAServerV2:
 
         # response example: { "users": [0, 1, 2 ... ] }
         response = []
-        for request in requests:
-            requestData = request[1]  # (socket, data)
-            response.append(int(requestData["idx"]))
+        for _, requestData in requests: # (socket, data)
+            response.append(int(requestData["index"]))
             yu_ = mhelper.dic_of_list_to_weights(requestData["yu"])
             self.yu_list.append(yu_)
 
         self.broadcast(requests, {"users": response})
 
     def unmasking(self, requests):
-        # (one) request: {"idx": u, "ssk_shares": s_sk_shares_dic, "bu_shares": bu_shares_dic}
-        # if u2, u3 dropped, requests: [{"idx": 0, "ssk_shares": {2: s20_sk, 3: s30_sk}, "bu_shares": {1: b10, 4: b40}}, ...]
+        # (one) request: {"index": u, "ssk_shares": s_sk_shares_dic, "bu_shares": bu_shares_dic}
+        # if u2, u3 dropped, requests: [{"index": 0, "ssk_shares": {2: s20_sk, 3: s30_sk}, "bu_shares": {1: b10, 4: b40}}, ...]
 
         s_sk_shares_dic = {}     # {2: [s20_sk, s21_sk, ... ], 3: [s30_sk, s31_sk, ... ], ... }
         bu_shares_dic = {}       # {0: [b10, b04, ... ], 1: [b10, b14, ... ], ... }
 
         # get s_sk_shares_dic, bu_shares_dic of user2\3, user3
-        for request in requests:
-            requestData = request[1]  # (socket, data)
+        for _, requestData in requests: # (socket, data)
             ssk_shares = literal_eval(requestData["ssk_shares"])
             for i, share in ssk_shares.items():
                 try: 


### PR DESCRIPTION
## 개요
- `BasicSA` 에서 나던 오류 수정 및 코드 리팩토링 조금

## 작업사항
- `BasicSA` 에서 다음과 같은 오류가 가끔 발생했었는데, 원인 파악 및 수정 완료
  ```
      decrypted = decryptor.decrypt(bytes.fromhex(ciphertext)).decode('utf-8')
  UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe4 in position 0: invalid continuation byte
  ```
  - 원인: key 분배를 사용자 index 를 고려하지 않고 수행해서 잘못된 key 로 인한 decryption 오류
  - key 분배 부분을 수정해서 잘 작동함을 확인했습니다.
- 일부 코드 리팩토링

## 확인할 사항
