### PR TITLE
Feat/main-server: add support for main lab-server/client

### DIFF
--- a/BasicSA.py
+++ b/BasicSA.py
@@ -10,7 +10,7 @@ p = 131
 
 # Get common values for server set-up: n, t, ...
 def getCommonValues():
-    global g, p
+    global g, p # TODO
 
     # R: domain
     # g: generator, p: prime

--- a/client/CSAClient.py
+++ b/client/CSAClient.py
@@ -16,7 +16,7 @@ ENCODING = 'utf-8'
 
 class CSAClient:
     HOST = 'localhost'
-    PORT = 7000
+    PORT = 8000
     verifyRound = 'verify'
     isBasic = True # true if BasicCSA, else FullCSA
 

--- a/client/CSAClient.py
+++ b/client/CSAClient.py
@@ -51,6 +51,7 @@ class CSAClient:
         self.cluster = setupDto.cluster
         self.clusterN = setupDto.clusterN
         self.index = setupDto.index
+        self.quantizationLevel = setupDto.qLevel
         self.others_keys = {int(key): value for key, value in literal_eval(setupDto.cluster_keys).items()}
         self.others_keys.pop(self.index)
 

--- a/client/HeteroSAClient.py
+++ b/client/HeteroSAClient.py
@@ -16,7 +16,7 @@ ENCODING = 'utf-8'
 
 class HeteroSAClient:
     HOST = 'localhost'
-    PORT = 7000
+    PORT = 7002
     xu = 0  # temp. local model of this client
 
     u = 0  # u = user index

--- a/client/HeteroSAClient.py
+++ b/client/HeteroSAClient.py
@@ -25,6 +25,7 @@ class HeteroSAClient:
     index = 0
     B = []
     G = perGroup = 0
+    quantization_levels = []
     
     my_keys = {}  # c_pk, c_sk, s_pk, s_sk of this client
     others_keys = {}  # other users' public key dic\
@@ -51,6 +52,7 @@ class HeteroSAClient:
         self.index = setupDto.index
         self.B = setupDto.B
         self.G = self.perGroup = setupDto.G # (For now,) G == groups num == users num of one group
+        self.quantization_levels = setupDto.quantization_levels
 
         self.data = setupDto.data
         global_weights = mhelper.dic_of_list_to_weights(literal_eval(setupDto.weights))
@@ -127,8 +129,9 @@ class HeteroSAClient:
                 self.group,
                 self.perGroup,
                 self.weights_interval,
-                self.euv_list, 
-                s_pk_dic,
+                self.euv_list,
+                self.s_pk_dic,
+                self.quantization_levels,
                 self.p,
                 self.R
         )

--- a/client/LabClients.py
+++ b/client/LabClients.py
@@ -66,7 +66,8 @@ if __name__ == "__main__":
 
     host = 'localhost'
     port = 6000
-    sendRequest(host, port, mode, {'n': n, 'k': k})
+    args = {'t': int(n/2), 'perGroup': 2, 'G': 2, 'qLevel': 30}
+    sendRequest(host, port, mode, {'n': n, 'k': k, 'args': args})
 
     # thread
     for _ in range(n):

--- a/client/LabClients.py
+++ b/client/LabClients.py
@@ -66,7 +66,8 @@ if __name__ == "__main__":
 
     host = 'localhost'
     port = 6000
-    args = {'t': int(n/2), 'perGroup': 2, 'G': 2, 'qLevel': 30}
+    quantization_levels = [20, 30, 60, 80, 100]
+    args = {'t': int(n/2), 'perGroup': 2, 'G': 2, 'qLevel': 30, 'quantization_levels': quantization_levels}
     sendRequest(host, port, mode, {'n': n, 'k': k, 'args': args})
 
     # thread

--- a/client/LabClients.py
+++ b/client/LabClients.py
@@ -1,0 +1,74 @@
+import threading
+
+from BasicSAClient import BasicSAClient, sendRequest
+from TurboClient import TurboClient
+from HeteroSAClient import HeteroSAClient
+from CSAClient import CSAClient
+
+def runOneClient(mode, k):
+    if mode == 0: # BasicSA
+        client = BasicSAClient()
+        for _ in range(k):
+            client.setUp()
+            client.advertiseKeys()
+            client.shareKeys()
+            client.maskedInputCollection()
+            client.unmasking()
+
+    elif mode == 1: # Turbo
+        client = TurboClient()
+        for _ in range(k):
+            group = client.setUp()
+            if group != 0:
+                client.turbo()
+            client.turbo_value()
+            client.turbo_final()
+
+    #elif mode == 2: # BREA
+
+    elif mode == 3: # HeteroSA
+        client = HeteroSAClient()
+        for _ in range(k):
+            client.setUp()
+            client.advertiseKeys()
+            client.shareKeys()
+            client.maskedInputCollection()
+            client.unmasking()
+
+    elif mode == 4: # BasicCSA
+        client = CSAClient(isBasic = True)
+        for _ in range(3):
+            client.setUp()
+            client.shareRandomMasks()
+            client.sendSecureWeight()
+
+    elif mode == 5: # FullCSA
+        client = CSAClient(isBasic = False)
+        for _ in range(3):
+            client.setUp()
+            client.shareRandomMasks()
+            client.sendSecureWeight()
+
+
+if __name__ == "__main__":
+    # args
+    k = 3       # rounds
+    n = 4       # number of users
+    mode = 0
+    """ mode
+    0: BasicSA Client
+    1: Turbo Client
+    2: BREA Client
+    3: HeteroSA Client
+    4: BasicCSA Client
+    5: FullCSA Client
+    """
+
+    host = 'localhost'
+    port = 6000
+    sendRequest(host, port, mode, {'n': n, 'k': k})
+
+    # thread
+    for _ in range(n):
+        thread = threading.Thread(target=runOneClient, args=(mode, k))
+        thread.start()

--- a/client/TurboClient.py
+++ b/client/TurboClient.py
@@ -10,7 +10,7 @@ import learning.models_helper as mhelper
 
 class TurboClient:
     HOST = 'localhost'
-    PORT = 7000
+    PORT = 7001
     xu = 0  # temp. local model of this client
 
     u = 0  # u = user index

--- a/dto/CSASetupDto.py
+++ b/dto/CSASetupDto.py
@@ -11,5 +11,6 @@ class CSASetupDto(NamedTuple):
     clusterN: int   # number of nodes in cluster
     cluster_keys: dict
     index: int
+    qLevel: int
     data: dict
     weights: dict

--- a/dto/HeteroSetupDto.py
+++ b/dto/HeteroSetupDto.py
@@ -10,6 +10,7 @@ class HeteroSetupDto(NamedTuple):
     index: int
     B: list
     G: int
+    quantization_levels: list
     data: dict
     weights: dict
     weights_interval: list

--- a/server/BasicSAServerV2.py
+++ b/server/BasicSAServerV2.py
@@ -27,9 +27,10 @@ class BasicSAServerV2:
     yu_list = []
     R = 0
 
-    def __init__(self, n, k):
+    def __init__(self, n, k, t):
         self.n = n
         self.k = k # Repeat the entire process k times
+        self.t = t # threshold
         self.serverSocket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.serverSocket.bind((self.host, self.port))
         self.serverSocket.settimeout(self.timeout)
@@ -139,7 +140,7 @@ class BasicSAServerV2:
         commonValues = getCommonValues()
         self.R = commonValues["R"]
         commonValues["n"] = usersNow
-        self.t = commonValues["t"] = int(usersNow / 2) # threshold
+        commonValues["t"] = self.t
 
         if self.model == {}:
             self.model = fl.setup()
@@ -265,5 +266,5 @@ class BasicSAServerV2:
         self.serverSocket.close()
 
 if __name__ == "__main__":
-    server = BasicSAServerV2(n=3, k=5)
+    server = BasicSAServerV2(n=3, k=5, t=1)
     server.start()

--- a/server/CSAServer.py
+++ b/server/CSAServer.py
@@ -12,7 +12,7 @@ import learning.utils as utils
 
 class CSAServer:
     host = 'localhost'
-    port = 7000
+    port = 8000
     SIZE = 2048
     ENCODING = 'utf-8'
     interval = 10 # server waits in one round # second

--- a/server/CSAServer.py
+++ b/server/CSAServer.py
@@ -34,9 +34,10 @@ class CSAServer:
     S_list = {}
     IS = {} # intermediate sum
 
-    def __init__(self, n, k, isBasic):
+    def __init__(self, n, k, isBasic, qLevel):
         self.n = n
         self.k = k # Repeat the entire process k times
+        self.quantizationLevel = qLevel
         self.isBasic = isBasic
         self.serverSocket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.serverSocket.bind((self.host, self.port))
@@ -196,6 +197,7 @@ class CSAServer:
                     clusterN = self.perGroup[i],
                     cluster_keys = str(hex_keys[i]), # node's id and public key
                     index = j,
+                    qLevel = self.quantizationLevel,
                     data = [int(k) for k in user_groups[c]],
                     weights= str(model_weights_list),
                 )._asdict()
@@ -291,6 +293,6 @@ class CSAServer:
 
 
 if __name__ == "__main__":
-    server = CSAServer(n=4, k=3, isBasic = True) # Basic CSA
-    # server = CSAServer(n=4, k=1, isBasic = False) # Full CSA
+    server = CSAServer(n=4, k=3, isBasic = True, qLevel=30) # Basic CSA
+    # server = CSAServer(n=4, k=1, isBasic = False, qLevel=30) # Full CSA
     server.start()

--- a/server/HeteroSAServer.py
+++ b/server/HeteroSAServer.py
@@ -24,10 +24,11 @@ class HeteroSAServer(BasicSAServerV2):
     segment_yu = {}
     surviving_users = []
 
-    def __init__(self, n, k, t, G, perGroup):
+    def __init__(self, n, k, t, G, perGroup, quantization_levels):
         super().__init__(n, k, t)
         self.G = G
         self.perGroup = perGroup
+        self.quantization_levels = quantization_levels
 
     # broadcast common value
     def setUp(self, requests):
@@ -72,6 +73,7 @@ class HeteroSAServer(BasicSAServerV2):
                     index = idx, 
                     B = self.B, 
                     G = self.G,
+                    quantization_levels = self.quantization_levels,
                     data = [int(k) for k in user_groups[idx]],
                     weights= str(model_weights_list),
                     weights_interval = weights_interval
@@ -171,7 +173,8 @@ class HeteroSAServer(BasicSAServerV2):
             self.surviving_users, 
             self.users_keys, 
             s_sk_dic,
-            bu_shares_dic, 
+            bu_shares_dic,
+            self.quantization_levels,
             self.R
         )
         #print(f'segment_xu: {segment_xu}')
@@ -191,5 +194,6 @@ class HeteroSAServer(BasicSAServerV2):
         fl.test_model(self.model)
 
 if __name__ == "__main__":
-    server = HeteroSAServer(n=4, k=5, t=2, G=2, perGroup=2)
+    quantization_levels = [20, 30, 60, 80, 100]
+    server = HeteroSAServer(n=4, k=5, t=2, G=2, perGroup=2, quantization_levels=quantization_levels)
     server.start()

--- a/server/HeteroSAServer.py
+++ b/server/HeteroSAServer.py
@@ -13,6 +13,7 @@ import learning.models_helper as mhelper
 
 class HeteroSAServer(BasicSAServerV2):
     users_keys = {}
+    port = 7002
     n = 4 # expected (== G * perGroup == G * G)
     t = 1
     R = 0

--- a/server/HeteroSAServer.py
+++ b/server/HeteroSAServer.py
@@ -24,8 +24,10 @@ class HeteroSAServer(BasicSAServerV2):
     segment_yu = {}
     surviving_users = []
 
-    def __init__(self, n, k):
-        super().__init__(n, k)
+    def __init__(self, n, k, t, G, perGroup):
+        super().__init__(n, k, t)
+        self.G = G
+        self.perGroup = perGroup
 
     # broadcast common value
     def setUp(self, requests):
@@ -35,7 +37,6 @@ class HeteroSAServer(BasicSAServerV2):
         self.surviving_users = []
 
         self.usersNow = len(requests)
-        self.t = int(self.usersNow / 2) # threshold
 
         commonValues = getCommonValues()
         self.R = commonValues["R"]
@@ -190,5 +191,5 @@ class HeteroSAServer(BasicSAServerV2):
         fl.test_model(self.model)
 
 if __name__ == "__main__":
-    server = HeteroSAServer(n=4, k=5)
+    server = HeteroSAServer(n=4, k=5, t=2, G=2, perGroup=2)
     server.start()

--- a/server/LabServer.py
+++ b/server/LabServer.py
@@ -18,7 +18,7 @@ def runServer(mode, k, n, args):
 
     elif mode == 3: # HeteroSA
         # WARN G == perGroup
-        server = HeteroSAServer(n=n, k=k, t=args['t'], G=args['G'], perGroup=args['perGroup'])
+        server = HeteroSAServer(n=n, k=k, t=args['t'], G=args['G'], perGroup=args['perGroup'], quantization_levels=args['quantization_levels'])
         server.start()
 
     elif mode == 4: # BasicCSA

--- a/server/LabServer.py
+++ b/server/LabServer.py
@@ -5,27 +5,28 @@ from TurboBaseServer import TurboServer
 from HeteroSAServer import HeteroSAServer
 from CSAServer import CSAServer
 
-def runServer(mode, k, n):
+def runServer(mode, k, n, args):
     if mode == 0: # BasicSA
-        server = BasicSAServerV2(n=n, k=k)
+        server = BasicSAServerV2(n=n, k=k, t=args['t'])
         server.start()
 
     elif mode == 1: # Turbo
-        server = TurboServer(n=n, k=k)
+        server = TurboServer(n=n, k=k, t=args['t'], perGroup=args['perGroup'])
         server.start()
 
     #elif mode == 2: # BREA
 
     elif mode == 3: # HeteroSA
-        server = HeteroSAServer(n=n, k=k)
+        # WARN G == perGroup
+        server = HeteroSAServer(n=n, k=k, t=args['t'], G=args['G'], perGroup=args['perGroup'])
         server.start()
 
     elif mode == 4: # BasicCSA
-        server = CSAServer(n=n, k=k, isBasic = True)
+        server = CSAServer(n=n, k=k, isBasic=True, qLevel=args['qLevel'])
         server.start()
 
     elif mode == 5: # FullCSA
-        server = CSAServer(n=n, k=k, isBasic = False)
+        server = CSAServer(n=n, k=k, isBasic=False, qLevel=args['qLevel'])
         server.start()
 
 
@@ -59,8 +60,9 @@ class LabServer:
                     request = request + received
 
                 requestData = json.loads(request)
-                k = int(requestData['k'])    # rounds
-                n = int(requestData['n'])    # number of users
+                k = int(requestData['k'])       # rounds
+                n = int(requestData['n'])       # number of users
+                args = requestData['args']      # additional arguments (dict)
                 mode = int(requestData['request'])
                 """ mode
                 0: BasicSA Client
@@ -74,7 +76,7 @@ class LabServer:
                     raise AttributeError
 
                 print(f'[SERVER] Client: {addr}, request: {request}')
-                thread = threading.Thread(target=runServer, args=(mode, k, n))
+                thread = threading.Thread(target=runServer, args=(mode, k, n, args))
                 thread.start()
 
             except socket.timeout:

--- a/server/LabServer.py
+++ b/server/LabServer.py
@@ -1,0 +1,95 @@
+import socket, json, time, threading
+
+from BasicSAServerV2 import BasicSAServerV2
+from TurboBaseServer import TurboServer
+from HeteroSAServer import HeteroSAServer
+from CSAServer import CSAServer
+
+def runServer(mode, k, n):
+    if mode == 0: # BasicSA
+        server = BasicSAServerV2(n=n, k=k)
+        server.start()
+
+    elif mode == 1: # Turbo
+        server = TurboServer(n=n, k=k)
+        server.start()
+
+    #elif mode == 2: # BREA
+
+    elif mode == 3: # HeteroSA
+        server = HeteroSAServer(n=n, k=k)
+        server.start()
+
+    elif mode == 4: # BasicCSA
+        server = CSAServer(n=n, k=k, isBasic = True)
+        server.start()
+
+    elif mode == 5: # FullCSA
+        server = CSAServer(n=n, k=k, isBasic = False)
+        server.start()
+
+
+class LabServer:
+    host = 'localhost'
+    port = 6000
+    SIZE = 2048
+    ENCODING = 'utf-8'
+
+    def start(self):
+        serverSocket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        serverSocket.bind((self.host, self.port))
+        serverSocket.listen()
+        print(f'[SERVER] Server started')
+
+        while True:
+            currentClient = socket
+            try:
+                clientSocket, addr = serverSocket.accept()
+                currentClient = clientSocket
+
+                # receive client data
+                # client request must ends with "\r\n"
+                request = ''
+                while True:
+                    received = str(clientSocket.recv(self.SIZE), self.ENCODING)
+                    if received.endswith("\r\n"):
+                        received = received.replace("\r\n", "")
+                        request = request + received
+                        break
+                    request = request + received
+
+                requestData = json.loads(request)
+                k = int(requestData['k'])    # rounds
+                n = int(requestData['n'])    # number of users
+                mode = int(requestData['request'])
+                """ mode
+                0: BasicSA Client
+                1: Turbo Client
+                2: BREA Client
+                3: HeteroSA Client
+                4: BasicCSA Client
+                5: FullCSA Client
+                """
+                if mode < 0 or mode > 5:
+                    raise AttributeError
+
+                print(f'[SERVER] Client: {addr}, request: {request}')
+                thread = threading.Thread(target=runServer, args=(mode, k, n))
+                thread.start()
+
+            except socket.timeout:
+                pass
+            except AttributeError:
+                print(f'[SERVER] Exception: invalid request')
+                currentClient.sendall(bytes(f'Exception: invalid request', self.ENCODING))
+                pass
+            except:
+                print(f'[SERVER] Exception: invalid request or unknown server error')
+                currentClient.sendall(bytes('Exception: invalid request or unknown server error\r\n', self.ENCODING))
+                pass
+
+
+
+if __name__ == "__main__":
+    server = LabServer()
+    server.start()

--- a/server/TurboBaseServer.py
+++ b/server/TurboBaseServer.py
@@ -10,7 +10,7 @@ import learning.models_helper as mhelper
 
 class TurboServer:
     host = 'localhost'
-    port = 7000
+    port = 7001
     SIZE = 2048
     ENCODING = 'utf-8'
     t = 1 # threshold

--- a/server/TurboBaseServer.py
+++ b/server/TurboBaseServer.py
@@ -35,9 +35,11 @@ class TurboServer:
     drop_out = {}
     alpha = beta = []
 
-    def __init__(self, n, k):
-        self.n = n
+    def __init__(self, n, k, t, perGroup):
+        self.n = n # MUST be multiple of perGroup
         self.k = k # Repeat the entire process k times
+        self.t = t # threshold
+        self.perGroup = perGroup # number of clients per group
 
     def start(self):
         self.serverSocket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -230,9 +232,8 @@ class TurboServer:
         commonValues = getCommonValues()
         self.R = commonValues["R"]
         commonValues["n"] = self.n
-        commonValues["t"] = self.t = 1
-
-        commonValues["perGroup"] = self.perGroup = 2
+        commonValues["t"] = self.t
+        commonValues["perGroup"] = self.perGroup
 
         # generate common alpha/beta
         commonValues["alpha"], commonValues["beta"] = self.alpha, self.beta = generateRandomVectorSet(self.perGroup, commonValues["p"])
@@ -349,5 +350,5 @@ class TurboServer:
         print(f'[Turbo] Server finished')
 
 if __name__ == "__main__":
-    server = TurboServer(n=4, k=3)
+    server = TurboServer(n=4, k=3, t=2, perGroup=2)
     server.start()


### PR DESCRIPTION
## 개요
- (연구실 서버 구축에 따라) 메인으로 동작하는 서버 및 여러 client 를 동작시키는 코드 구현

## 작업사항
- LabServer: 요청에 따라 각 서버(우리가 그동안 구현한 여러 프로토콜의) 동작
- LabClients: LabServer 에 요청 보내기 및 해당 clients 를 필요한 만큼 생성(thread)해서 동작시키기
- 이에 따라, 각 protocol 별로 변경되는 값(threshold, per group, group num, quantization level 등)은 빼서 argument 로 넣어주게 했습니다. 추후 다른 분들의 작업을 합치면서 필요한 부분을 추가적으로 작업해갈 예정입니다.

## 확인할 사항
- 서버 코드는 실제로 쓰일지는 모르겠으나 아마 서버를 구축할 때 필요할 것으로 예상하고 작업했습니다!
