### PR TITLE
Feat/csa: add training weight (CSA V2)

### DIFF
--- a/CSA.py
+++ b/CSA.py
@@ -124,7 +124,7 @@ def generateSecureWeight(weight, ri, masks, p, a = 0):
         dict: secure weight Sj
     """
     sum_mask = ri - (sum(masks.values()) % p) + a
-    return [w + sum_mask for w in weight]
+    return [(w + sum_mask) % p for w in weight]
 
 
 def computeReconstructionValue(survived, my_masks, masks, cluster_indexes):

--- a/client/CSAClientV2.py
+++ b/client/CSAClientV2.py
@@ -42,6 +42,7 @@ class CSAClientV2(CSAClient):
         self.others_keys = {int(key): value for key, value in literal_eval(setupDto.cluster_keys).items()}
         self.others_keys.pop(self.index)
         self.training_weight = setupDto.training_weight
+        #print(self.training_weight)
 
         self.cluster_indexes.remove(self.index)
 
@@ -66,7 +67,7 @@ class CSAClientV2(CSAClient):
         self.weights_info, self.weight = mhelper.flatten_tensor(local_weight)
         self.weight = list(self.training_weight * x for x in self.weight)
         self.weight = stochasticQuantization(self.weight, self.quantizationLevel, self.p)
-        #print(local_weight['conv1.bias'])
+        #print(self.index, self.weight[250:260])
 
 
     def shareRandomMasks(self): # send random masks

--- a/client/LabClients.py
+++ b/client/LabClients.py
@@ -62,7 +62,7 @@ def runOneClient(mode, k, dropout = False):
             client.sendSecureWeight()
 
     elif mode == 6: # BasicCSA V2
-        client = CSAClientV2(isBasic = False)
+        client = CSAClientV2(isBasic = True)
         for _ in range(k):
             client.setUp()
             if not client.shareRandomMasks():
@@ -92,7 +92,7 @@ if __name__ == "__main__":
     #sendRequest(host, port, mode, {'n': n, 'k': k, 'args': args})
 
     # thread
-    dropout = int(n/2)
+    dropout = n#int(n/2)
     for i in range(n):
         if i >= dropout:
             threading.Thread(target=runOneClient, args=(mode, k, True)).start()

--- a/client/LabClients.py
+++ b/client/LabClients.py
@@ -67,7 +67,8 @@ def runOneClient(mode, k, dropout = False):
             client.setUp()
             if not client.shareRandomMasks():
                 continue
-            client.sendSecureWeight()
+            if not dropout:
+                client.sendSecureWeight()
 
 
 if __name__ == "__main__":
@@ -92,7 +93,7 @@ if __name__ == "__main__":
     #sendRequest(host, port, mode, {'n': n, 'k': k, 'args': args})
 
     # thread
-    dropout = n#int(n/2)
+    dropout = n #int(n/2)
     for i in range(n):
         if i >= dropout:
             threading.Thread(target=runOneClient, args=(mode, k, True)).start()

--- a/common.py
+++ b/common.py
@@ -5,7 +5,7 @@ from ast import literal_eval
 SIZE = 2048
 ENCODING = 'utf-8'
 
-def sendRequestV2(s, tag, request):
+def sendRequestV2(s, tag, request, delay=0):
     """ send request to server
     Args:
         s (socket): client's socket
@@ -17,10 +17,11 @@ def sendRequestV2(s, tag, request):
     request['request'] = tag
 
     # send request
+    time.sleep(delay)
     s.sendall(bytes(json.dumps(request) + "\r\n", ENCODING))
     # print(f"[{tag}] Send request (no response)")
 
-def sendRequestAndReceiveV2(s, tag, request):
+def sendRequestAndReceiveV2(s, tag, request, delay=0):
     """ send request and receive response to/from server
     Args:
         s (socket): client's socket
@@ -33,6 +34,7 @@ def sendRequestAndReceiveV2(s, tag, request):
     request['request'] = tag
 
     # send request
+    time.sleep(delay)
     s.sendall(bytes(json.dumps(request) + "\r\n", ENCODING))
     # print(f"[{tag}] Send request")
     # print(f"[{tag}] Send {request}")

--- a/server/CSAServer.py
+++ b/server/CSAServer.py
@@ -392,7 +392,7 @@ class CSAServer:
 
 if __name__ == "__main__":
     try:
-        server = CSAServer(n=4, k=3, isBasic = True, qLevel=30) # Basic CSA
+        server = CSAServer(n=4, k=3, isBasic = True, qLevel=100) # Basic CSA
         # server = CSAServer(n=4, k=1, isBasic = False, qLevel=30) # Full CSA
         server.start()
     except (KeyboardInterrupt, RuntimeError):

--- a/server/CSAServer.py
+++ b/server/CSAServer.py
@@ -90,6 +90,8 @@ class CSAServer:
                         try:
                             while True:
                                 received = str(clientSocket.recv(self.SIZE), self.ENCODING)
+                                #print(clientSocket.getpeername(), received, len(received))
+                                if len(received) == 0: break
                                 if received.endswith("\r\n"):
                                     received = received[:-2]
                                     requestData = requestData + received
@@ -98,8 +100,8 @@ class CSAServer:
                         except socket.timeout:
                             if requestData.endswith("\r\n"):
                                 requestData = requestData[:-2]
-                            pass
 
+                        if len(requestData) == 0: break
                         if requestData.find('}\r\n{') > 0: # for multiple requests at once
                             requestData_all = requestData.split('\r\n')
                         else:

--- a/server/CSAServerV2.py
+++ b/server/CSAServerV2.py
@@ -60,7 +60,7 @@ class CSAServerV2(CSAServer):
             self.clusters.append(i) # store clusters' index
             hex_keys[i] = {}
             self.users_keys[i] = {}
-            self.perLatency[i] = 20 + i*5
+            self.perLatency[i] = 40 + i*5
             self.num_items[i] = 3000 + i * 1000
             self.survived[i] = [j for j, request in cluster]
             for j, request in cluster:
@@ -185,7 +185,7 @@ class CSAServerV2(CSAServer):
 if __name__ == "__main__":
     server = ''
     try:
-        server = CSAServerV2(n=4, k=3, isBasic = True, qLevel=30) # Basic CSA
+        server = CSAServerV2(n=4, k=3, isBasic = True, qLevel=100) # Basic CSA
         server.start()
     except (KeyboardInterrupt, RuntimeError):
         server.writeResults()


### PR DESCRIPTION
## 개요
- CSA V2 작업

## 작업사항
- training weight 를 적용한 CSA V2 를 작업했습니다.
  - training weight 를 추가함에 따라 필요한 연산(수식) 적용, 검증 완료.
  - 각 cluster 당 다른 크기의 data set 를 가지도록 적용.
    다른 크기의 data set 을 만들어주는 `learning/sampling/mnist_iid_cluster()` 함수 작성.
  - parameters 수정: latency, data set 크기, quantization level
- 각 cluster 마다 수행 시간을 기록할 수 있도록 추가.

## 확인할 사항
- 이전 PR(#51) 에서 `fix/basicsa` 의 베이스 브랜치를 현 `feat/csa` 브랜치로 작업하셔서 CSA V2 에 대한 주요 작업 사항이 담긴 commit 인 [`d7d5cfe`](https://github.com/Lab-SA/SA/pull/51/commits/d7d5cfead91ddf1816ea9d2f54304799bc25eebf) 이 현재 PR 에서 누락되었습니다. 해당 commit 을 함께 봐주시면 감사하겠습니다! (PR 올릴 때 주의 부탁드립니다)
